### PR TITLE
Updating Calico

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,23 @@ env:
   - TEST_CASE=1.4
   - TEST_CASE=1.4-flannel
   - TEST_CASE=1.4-calico
+  - TEST_CASE=1.4-calico-kdd
   - TEST_CASE=1.4-weave
   - TEST_CASE=1.5
   - TEST_CASE=1.5-flannel
   - TEST_CASE=1.5-calico
+  - TEST_CASE=1.5-calico-kdd
   - TEST_CASE=1.5-weave
   - TEST_CASE=1.6
   # - TEST_CASE=1.6-flannel
   - TEST_CASE=1.6-calico
+  - TEST_CASE=1.6-calico-kdd
   # - TEST_CASE=1.6-weave
   - TEST_CASE=src-1.6
   - TEST_CASE=src-master
   # - TEST_CASE=src-master-flannel
   # - TEST_CASE=src-master-calico
+  # - TEST_CASE=src-calico-kdd
   # - TEST_CASE=src-master-weave
 
 before_install:

--- a/config.sh
+++ b/config.sh
@@ -29,10 +29,15 @@ DIND_IMAGE="${DIND_IMAGE:-mirantis/kubeadm-dind-cluster:v1.6}"
 # Set custom URL for Dashboard yaml file
 # DASHBOARD_URL="${DASHBOARD_URL:-https://rawgit.com/kubernetes/dashboard/bfab10151f012d1acc5dfb1979f3172e2400aa3c/src/deploy/kubernetes-dashboard.yaml}"
 
-# CNI plugin to use (bridge, flannel, calico, weave). Defaults to 'bridge'
+# CNI plugin to use (bridge, flannel, calico, calico-kdd, weave). Defaults to 'bridge'
 # In case of 'bridge' plugin, additional hacks are employed to bridge
 # DIND containers together.
 CNI_PLUGIN="${CNI_PLUGIN:-bridge}"
+
+# When using Calico with Kubernetes as the datastore (calico-kdd) your
+# controller manager needs to be started with `--cluster-cidr=192.168.0.0/16`.
+# More information here: http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/
+# POD_NETWORK_CIDR="192.168.0.0/16"
 
 # Set SKIP_SNAPSHOT to non-empty string to skip making the snapshot.
 # This may be useful for CI environment where the cluster is never

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -706,17 +706,17 @@ function dind::up {
       ;;
     calico)
       if dind::use-rbac; then
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
       else
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
       fi
       ;;
     calico-kdd)
       if dind::use-rbac; then
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/rbac.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/rbac.yaml
       else
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
       fi
       ;;
     weave)

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -48,6 +48,7 @@ fi
 
 CNI_PLUGIN="${CNI_PLUGIN:-bridge}"
 DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
+POD_NETWORK_CIDR="${POD_NETWORK_CIDR:-10.244.0.0/16}"
 dind_ip_base="$(echo "${DIND_SUBNET}" | sed 's/\.0$//')"
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
@@ -537,7 +538,7 @@ function dind::init {
     # It doesn't change the fact that we're deploying custom-built k8s version
     kube_version_flag="--kubernetes-version=stable-1.6"
   fi
-  kubeadm_join_flags="$(dind::kubeadm "${container_id}" init --pod-network-cidr=10.244.0.0/16 --skip-preflight-checks ${kube_version_flag} "$@" | grep '^ *kubeadm join' | sed 's/^ *kubeadm join //')"
+  kubeadm_join_flags="$(dind::kubeadm "${container_id}" init --pod-network-cidr="${POD_NETWORK_CIDR}" --skip-preflight-checks ${kube_version_flag} "$@" | grep '^ *kubeadm join' | sed 's/^ *kubeadm join //')"
   dind::configure-kubectl
   dind::deploy-dashboard
 }
@@ -705,9 +706,17 @@ function dind::up {
       ;;
     calico)
       if dind::use-rbac; then
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
       else
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+      fi
+      ;;
+    calico-kdd)
+      if dind::use-rbac; then
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/rbac.yaml
+      else
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.2/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
       fi
       ;;
     weave)

--- a/fixed/dind-cluster-v1.4.sh
+++ b/fixed/dind-cluster-v1.4.sh
@@ -705,9 +705,17 @@ function dind::up {
       ;;
     calico)
       if dind::use-rbac; then
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
       else
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+      fi
+      ;;
+    calico-kdd)
+      if dind::use-rbac; then
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/rbac.yaml
+      else
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
       fi
       ;;
     weave)

--- a/fixed/dind-cluster-v1.5.sh
+++ b/fixed/dind-cluster-v1.5.sh
@@ -705,9 +705,17 @@ function dind::up {
       ;;
     calico)
       if dind::use-rbac; then
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
       else
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+      fi
+      ;;
+    calico-kdd)
+      if dind::use-rbac; then
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/rbac.yaml
+      else
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
       fi
       ;;
     weave)

--- a/fixed/dind-cluster-v1.6.sh
+++ b/fixed/dind-cluster-v1.6.sh
@@ -705,9 +705,17 @@ function dind::up {
       ;;
     calico)
       if dind::use-rbac; then
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.1/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.6/calico.yaml
       else
-        "${kubectl}" apply -f http://docs.projectcalico.org/v2.0/getting-started/kubernetes/installation/hosted/kubeadm/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubeadm/1.5/calico.yaml
+      fi
+      ;;
+    calico-kdd)
+      if dind::use-rbac; then
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.6/calico.yaml
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/rbac.yaml
+      else
+        "${kubectl}" apply -f http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/calico-networking/1.5/calico.yaml
       fi
       ;;
     weave)

--- a/test.sh
+++ b/test.sh
@@ -110,6 +110,14 @@ function test-case-1.4-calico {
   )
 }
 
+function test-case-1.4-calico-kdd {
+  (
+    export CNI_PLUGIN=calico-kdd
+    POD_NETWORK_CIDR="192.168.0.0/16"
+    test-case-1.4
+  )
+}
+
 function test-case-1.4-weave {
   (
     export CNI_PLUGIN=weave
@@ -147,6 +155,13 @@ function test-case-1.5-calico {
   )
 }
 
+function test-case-1.5-calico-kdd {
+  (
+    export CNI_PLUGIN=calico-kdd
+    POD_NETWORK_CIDR="192.168.0.0/16"
+    test-case-1.5
+  )
+}
 
 function test-case-1.5-weave {
   (
@@ -185,6 +200,14 @@ function test-case-1.6-calico {
   )
 }
 
+function test-case-1.6-calico-kdd {
+  (
+    export CNI_PLUGIN=calico-kdd
+    POD_NETWORK_CIDR="192.168.0.0/16"
+    test-case-1.6
+  )
+}
+
 function test-case-1.6-weave {
   (
     export CNI_PLUGIN=weave
@@ -209,7 +232,15 @@ function test-case-src-master-flannel {
 
 function test-case-src-master-calico {
   (
-    export CNI_PLUGIN=flannel
+    export CNI_PLUGIN=calico
+    test-cluster-src
+  )
+}
+
+function test-case-src-master-calico-kdd {
+  (
+    export CNI_PLUGIN=calico-kdd
+    POD_NETWORK_CIDR="192.168.0.0/16"
     test-cluster-src
   )
 }
@@ -225,20 +256,24 @@ if [[ ! ${TEST_CASE} ]]; then
   test-case-1.4
   test-case-1.4-flannel
   test-case-1.4-calico
+  test-case-1.4-calico-kdd
   test-case-1.4-weave
   test-case-1.5
   test-case-1.5-flannel
   test-case-1.5-calico
+  test-case-1.5-calico-kdd
   test-case-1.5-weave
   test-case-1.6
-  test-case-1.6-flannel
+  # test-case-1.6-flannel
   test-case-1.6-calico
-  test-case-1.6-weave
+  test-case-1.6-calico-kdd
+  # test-case-1.6-weave
   test-case-src-1.6
   test-case-src-master
-  test-case-src-master-flannel
-  test-case-src-master-calico
-  test-case-src-master-weave
+  # test-case-src-master-flannel
+  # test-case-src-master-calico
+  # test-case-src-calico-kdd
+  # test-case-src-master-weave
 else
   "test-case-${TEST_CASE}"
 fi


### PR DESCRIPTION
I've brought Calico to the latest release ([2.3](http://docs.projectcalico.org/v2.3/releases/) and added an option to use [Calico using Kubernetes](http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/) as a datastore.

Adding the Calico Kubernetes datastore required fiddling with the POD_NETWORK_CIDR, to match the Calico manifest.  I have added it as an option that defaults to what it was originally.

`POD_NETWORK_CIDR="${POD_NETWORK_CIDR:-10.244.0.0/16}"`