### PR TITLE
Allow customization of gce-setup.sh and fix dind-cluster.sh bug

### DIFF
--- a/gce-setup.sh
+++ b/gce-setup.sh
@@ -20,6 +20,7 @@ else
 fi
 DIND_ROOT="$(cd $(dirname "$(readlinkf "${BASH_SOURCE}")"); pwd)"
 KUBE_DIND_GCE_PROJECT="${KUBE_DIND_GCE_PROJECT:-$(gcloud config list --format 'value(core.project)' 2>/dev/null)}"
+KUBE_DIND_GCE_ZONE="${KUBE_DIND_GCE_ZONE:-$(gcloud config list --format 'value(compute.zone)' 2>/dev/null)}"
 # Based on instructions from k8s build/README.md
 if [ -z "${KUBE_DIND_GCE_PROJECT:-}" ]; then
     echo >&2 "Please set KUBE_DIND_GCE_PROJECT or use 'gcloud config set project NAME'"
@@ -27,14 +28,14 @@ if [ -z "${KUBE_DIND_GCE_PROJECT:-}" ]; then
 fi
 
 set -x
-KUBE_DIND_VM=k8s-dind
+KUBE_DIND_VM="${KUBE_DIND_VM:-k8s-dind}"
 export KUBE_RSYNC_PORT=8730
 export APISERVER_PORT=8899
 docker-machine create \
                --driver=google \
                --google-project=${KUBE_DIND_GCE_PROJECT} \
                --google-machine-image=ubuntu-os-cloud/global/images/ubuntu-1604-xenial-v20170307 \
-               --google-zone=us-west1-a \
+               --google-zone=${KUBE_DIND_GCE_ZONE} \
                --google-machine-type=n1-standard-8 \
                --google-disk-size=50 \
                --google-disk-type=pd-ssd \


### PR DESCRIPTION
It looks like e2e.go has changed the -check_version_skew argument to
-check-version-skew. Changed the dind-cluster-v1.7.sh too.

Allowing user to override VM name, so that gce-setup.sh could be used
from multiple machines at once.  Allowing zone to be overridden by
user,a nd if not, will use gcloud config to set zone. This supports
developers running from different locations.