### PR TITLE
Don't fail if kubernetes repo pulled already.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -66,7 +66,9 @@ function test-cluster {
 function test-cluster-src {
   (
     local version="${1:-}"
-    git clone https://github.com/kubernetes/kubernetes.git
+    if [[ ! -d "kubernetes" ]]; then
+       git clone https://github.com/kubernetes/kubernetes.git
+    fi
     cd kubernetes
     if [[ ${version} ]]; then
       git checkout "${version}"
@@ -220,7 +222,7 @@ function test-case-src-1.7 {
 }
 
 function test-case-src-master {
-  test-cluster-src
+  test-cluster-src master
 }
 
 function test-case-src-master-flannel {


### PR DESCRIPTION
This fixes the issue where two tests (src-1.7 and src-master) both try
to clone the kubernetes repo, and the latter fails, because the repo
already exists. Seen in local testing.

A secondary purpose of this commit is to check the baseline CI testing
for DinD (s it doesn't change any DinD code). There is a concern that
there may be problems with the two src test cases in test.sh.