### PR TITLE
fixed scripts: Update e2e.go command

### DIFF
--- a/fixed/dind-cluster-v1.6.sh
+++ b/fixed/dind-cluster-v1.6.sh
@@ -852,7 +852,7 @@ function dind::do-run-e2e {
          bash -c "cluster/kubectl.sh config set-cluster dind --server='http://localhost:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
-         go run hack/e2e.go --v --test --test_args='${test_args}'"
+         go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
 }
 
 function dind::clean {

--- a/fixed/dind-cluster-v1.7.sh
+++ b/fixed/dind-cluster-v1.7.sh
@@ -852,7 +852,7 @@ function dind::do-run-e2e {
          bash -c "cluster/kubectl.sh config set-cluster dind --server='http://localhost:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
-         go run hack/e2e.go --v --test -check_version_skew=false --test_args='${test_args}'"
+         go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
 }
 
 function dind::clean {


### PR DESCRIPTION
- Fixes errors in 1.7 script due to invalid `--check_version_skew=false` flag
- Adds `--check-version-skew=false` back to 1.6 script
- Avoids warning by using a `--` separator befor kubetest flags

Related to #30