### PR TITLE
Provide IPv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,105 @@ The first `dind/dind-cluster.sh up` invocation can be slow because it
 needs to build the base image and Kubernetes binaries. Subsequent
 invocations are much faster.
 
+## IPv6 Mode (experimental)
+To run Kubernetes in IPv6 only mode, the following steps can be performed
+in a Kubernetes source setup. First, build a new kubeadm-dind-cluster
+image, from the DinD area:
+
+```shell
+$ cd ~/dind
+
+$ build/build-local.sh
+$ export DIND_IMAGE=mirantis/kubeadm-dind-cluster:local
+```
+
+Next, clone a Kubernetes repo from master branch:
+
+```shell
+$ git clone https://github.com/kubernetes/kubernetes.git
+$ cd kubernetes
+```
+
+As of Oct. 23rd, 2017, the following IPv6 PRs are in-flight, and should
+be cherry picked and added to the repo:
+
+```
+PR #53484 "Adds Support for Configurable Kubeadm Probes."
+PR #45551 "Adds Support for Node Resource IPv6 Addressing"
+PR #53148 "ip6tables should be set in the noop plugin"
+PR #52180 "Updating kubenet for CNI with IPv6"
+PR #45792 "Updating NewCIDRSet return a value"
+PR #50929 "Add kubeadm config for setting kube-proxy bind address"
+PR #53555 "Add IPv6 and negative UT test cases for proxier's deleteEndpointConnections"
+PR #52748 "Add brackets around IPv6 addrs in e2e test IP:port endpoints"
+PR #54639 "Updates kube-dns in kubeadm to 1.14.7"
+PR #54437 "Adds support for v4/v6 loopback dns bind address."
+```
+
+These can be obtained with doing cherry picks from the PR commits:
+```
+git fetch origin pull/53484/head:pr53484
+git log --abbrev-commit pr53484 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/45551/head:pr45551
+git log --abbrev-commit pr45551 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/53184/head:pr53184
+git log --abbrev-commit pr53184 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/52180/head:pr52180
+git log --abbrev-commit pr52180 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/45792/head:pr45792
+git log --abbrev-commit pr45792 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+```
+
+Had conflict on above and needed to resolve.
+
+```
+git fetch origin pull/50929/head:pr50929
+git log --abbrev-commit pr50929 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/53555/head:pr53555
+git log --abbrev-commit pr53555 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/52748/head:pr52748
+git log --abbrev-commit pr52748 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/54639/head:pr54639
+git log --abbrev-commit pr54639 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+
+git fetch origin pull/54437/head:pr54437
+git log --abbrev-commit pr54437 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
+```
+
+If you have a host that allows four times more conntrack connection (max) than
+hashsize, You'll need this temporary patch (until issue 50787 is fixed and DinD is
+modified to customize the kubelet config file):
+
+https://github.com/pmichali/kubernetes/commit/d76164d919f292915ebaf69d8a3c357f40457bd7
+
+Lastly, set up environment variables for building and IPv6 mode and
+then bring up the cluster:
+
+```shell
+$ export BUILD_KUBEADM=y
+$ export BUILD_HYPERKUBE=y
+$ export IP_MODE=ipv6
+
+$ ../dind-cluster.sh up
+```
+
+Note: there are additional customizations that you can make for IPv6,
+to set the prefix used for DNS64, subnet prefix to use for DinD, and
+the service subnet CIDR:
+
+```shell
+export DNS64_PREFIX=fd00:77:64:ff9b::
+export DIND_SUBNET=fd00:77::
+export SERVICE_CIDR=fd00:77:30::/110
+```
+
 ## Configuration
 You may edit `config.sh` to override default settings. See comments in
 [the file](config.sh) for more info. In particular, you can specify

--- a/config.sh
+++ b/config.sh
@@ -1,5 +1,10 @@
-# DIND subnet (/16 is always used)
-DIND_SUBNET=10.192.0.0
+if [[ ${IP_MODE} = "ipv4" ]]; then
+    # DinD subnet (expected to be /16)
+    DIND_SUBNET="10.192.0.0"
+else
+    # DinD subnet (expected to be /64)
+    DIND_SUBNET="fd00:10::"
+fi
 
 # Apiserver port
 APISERVER_PORT=${APISERVER_PORT:-8080}

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -42,6 +42,7 @@ fi
 
 #%CONFIG%
 
+IP_MODE="${IP_MODE:-ipv4}"  # ipv4, ipv6, (future) dualstack
 if [[ ! ${EMBEDDED_CONFIG:-} ]]; then
   source "${DIND_ROOT}/config.sh"
 fi
@@ -51,9 +52,42 @@ if [[ CNI_PLUGIN = "calico" || CNI_PLUGIN = "calico-kdd" ]]; then
   DEFAULT_POD_NETWORK_CIDR="192.168.0.0/16"
 fi
 CNI_PLUGIN="${CNI_PLUGIN:-bridge}"
-DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
 POD_NETWORK_CIDR="${POD_NETWORK_CIDR:-${DEFAULT_POD_NETWORK_CIDR}}"
-dind_ip_base="$(echo "${DIND_SUBNET}" | sed 's/\.0$//')"
+ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
+GCE_HOSTED="${GCE_HOSTED:-false}"
+if [[ ${IP_MODE} = "ipv6" ]]; then
+    dind_ip_base="${DIND_SUBNET}"
+    ETCD_HOST="::1"
+    KUBE_RSYNC_ADDR="${KUBE_RSYNC_ADDR:-::1}"
+    SERVICE_CIDR="${SERVICE_CIDR:-fd00:10:30::/110}"
+    DIND_SUBNET_SIZE="${DIND_SUBNET_SIZE:-64}"
+    REMOTE_DNS64_V4SERVER="${REMOTE_DNS64_V4SERVER:-8.8.8.8}"
+    LOCAL_NAT64_SERVER="${DIND_SUBNET}200"
+    DNS64_PREFIX="${DNS64_PREFIX:-fd00:10:64:ff9b::}"
+    DNS64_PREFIX_SIZE="${DNS64_PREFIX_SIZE:-96}"
+    DNS64_PREFIX_CIDR="${DNS64_PREFIX}/${DNS64_PREFIX_SIZE}"
+    dns_server="${dind_ip_base}100"
+    # Create a /64 prefix so that created /80 pod net is inside the /64 DinD network
+    POD_NET_PREFIX="$(echo $DIND_SUBNET | sed 's/::$//')"
+    num_colons="$(grep -o ":" <<< "${POD_NET_PREFIX}" | wc -l)"
+    while [ $num_colons -lt 3 ]; do
+	POD_NET_PREFIX+=":0"
+	let num_colons+=1
+    done
+else
+    dind_ip_base="$(echo "${DIND_SUBNET}" | sed 's/0$//')"
+    KUBE_RSYNC_ADDR="${KUBE_RSYNC_ADDR:-127.0.0.1}"
+    SERVICE_CIDR="${SERVICE_CIDR:-10.96.0.0/12}"
+    DIND_SUBNET_SIZE="${DIND_SUBNET_SIZE:-16}"
+    dns_server="${REMOTE_DNS64_V4SERVER:-8.8.8.8}"
+fi
+dns_prefix="$(echo ${SERVICE_CIDR} | sed 's,/.*,,')"
+if [[ ${IP_MODE} != "ipv6" ]]; then
+    dns_prefix="$(echo ${dns_prefix} | sed 's/0$//')"
+fi
+kube_master_ip="${dind_ip_base}2"
+DNS_SVC_IP="${dns_prefix}10"
+
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
@@ -117,7 +151,7 @@ function dind::set-build-volume-args {
   if [ -n "${KUBEADM_DIND_LOCAL:-}" ]; then
     build_volume_args=(-v "$PWD:/go/src/k8s.io/kubernetes")
   else
-    build_container_name="$(KUBE_ROOT=$PWD &&
+    build_container_name="$(KUBE_ROOT=${PWD} ETCD_HOST=${ETCD_HOST} &&
                             . ${build_tools_dir}/common.sh &&
                             kube::build::verify_prereqs >&2 &&
                             echo "${KUBE_DATA_CONTAINER_NAME:-${KUBE_BUILD_DATA_CONTAINER_NAME}}")"
@@ -372,7 +406,12 @@ function dind::ensure-binaries {
 
 function dind::ensure-network {
   if ! docker network inspect kubeadm-dind-net >&/dev/null; then
-    docker network create --subnet="${DIND_SUBNET}/16" kubeadm-dind-net >/dev/null
+    local v6settings=""
+    if [[ ${IP_MODE} = "ipv6" ]]; then
+      # Need second network for NAT64
+      v6settings="--subnet=172.18.0.0/16 --ipv6"
+    fi
+    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" kubeadm-dind-net >/dev/null
   fi
 }
 
@@ -394,6 +433,66 @@ function dind::ensure-volume {
   dind::create-volume "${name}"
 }
 
+function dind::ensure-dns {
+    if [[ ${IP_MODE} = "ipv6" ]]; then
+        if ! docker inspect bind9 >&/dev/null; then
+	    local bind9_path=/tmp/bind9
+	    rm -rf ${bind9_path}
+	    mkdir -p ${bind9_path}/conf ${bind9_path}/cache
+	    cat >${bind9_path}/conf/named.conf <<BIND9_EOF
+options {
+    directory "/var/bind";
+    allow-query { any; };
+    forwarders {
+        ${DNS64_PREFIX}${REMOTE_DNS64_V4SERVER};
+    };
+    auth-nxdomain no;    # conform to RFC1035
+    listen-on-v6 { any; };
+    dns64 ${DNS64_PREFIX_CIDR} {
+        exclude { any; };
+    };
+};
+BIND9_EOF
+	    if [[ "${GCE_HOSTED}" = true ]]; then
+		# TODO: Have bind9 create config file, and pass in variables via Env vars.
+		docker-machine scp ${bind9_path}/conf/named.conf k8s-dind:bind9-named.conf
+		docker-machine ssh k8s-dind sudo rm -rf ${bind-path}
+		docker-machine ssh k8s-dind sudo mkdir -p ${bind9_path}/conf ${bind9_path}/cache
+		docker-machine ssh k8s-dind sudo cp /home/docker-user/bind9-named.conf ${bind9_path}/conf/named.conf
+	    fi
+	    docker run -d --name bind9 --hostname bind9 --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
+		   --privileged=true --ip6 $dns_server --dns $dns_server \
+		   -v ${bind9_path}/conf/named.conf:/etc/bind/named.conf \
+		   resystit/bind9:latest >/dev/null
+	    ipv4_addr="$(docker exec bind9 ip addr list eth0 | grep "inet" | awk '$1 == "inet" {print $2}')"
+	    docker exec bind9 ip addr del ${ipv4_addr} dev eth0
+	    docker exec bind9 ip -6 route add ${DNS64_PREFIX_CIDR} via ${LOCAL_NAT64_SERVER}
+        fi
+    fi
+}
+
+function dind::ensure-nat {
+    if [[  ${IP_MODE} = "ipv6" ]]; then
+        if ! docker ps | grep tayga >&/dev/null; then
+            docker run -d --name tayga --hostname tayga --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
+		   --privileged=true --ip 172.18.0.200 --ip6 ${LOCAL_NAT64_SERVER} --dns ${REMOTE_DNS64_V4SERVER} --dns ${dns_server} \
+		   -e TAYGA_CONF_PREFIX=${DNS64_PREFIX_CIDR} -e TAYGA_CONF_IPV4_ADDR=172.18.0.200 \
+		   danehans/tayga:latest >/dev/null
+	    # TODO Way to add route w/o sudo? Need to check/create, as "clean" may remove route
+	    local route="$(ip route | egrep "^172.18.0.128/25")"
+	    if [[ -z "${route}" ]]; then
+		if [[ "${GCE_HOSTED}" = true ]]; then
+		    docker-machine ssh k8s-dind sudo ip route add 172.18.0.128/25 via 172.18.0.200
+		else
+		    sudo ip route add 172.18.0.128/25 via 172.18.0.200
+		fi
+	    fi
+	fi
+    fi
+}
+
 function dind::run {
   local reuse_volume=
   if [[ $1 = -r ]]; then
@@ -409,9 +508,22 @@ function dind::run {
   else
     shift $#
   fi
-  local -a opts=(--ip "${ip}" "$@")
+  local ip_arg="--ip"
+  if [[ ${IP_MODE} = "ipv6" ]]; then
+      ip_arg="--ip6"
+  fi
+  local -a opts=("${ip_arg}" "${ip}" "$@")
   local -a args=("systemd.setenv=CNI_PLUGIN=${CNI_PLUGIN}")
-
+  args+=("systemd.setenv=IP_MODE=${IP_MODE}")
+  if [[ ${IP_MODE} = "ipv6" ]]; then
+      opts+=(--sysctl net.ipv6.conf.all.disable_ipv6=0)
+      opts+=(--sysctl net.ipv6.conf.all.forwarding=1)
+      opts+=(--dns ${dns_server})
+      args+=("systemd.setenv=DNS64_PREFIX_CIDR=${DNS64_PREFIX_CIDR}")
+      args+=("systemd.setenv=LOCAL_NAT64_SERVER=${LOCAL_NAT64_SERVER}")
+      args+=("systemd.setenv=POD_NET_PREFIX=${POD_NET_PREFIX}")
+  fi
+  args+=("systemd.setenv=DNS_SVC_IP=${DNS_SVC_IP}")
   if [[ ! "${container_name}" ]]; then
     echo >&2 "Must specify container name"
     exit 1
@@ -439,6 +551,8 @@ function dind::run {
   volume_name="kubeadm-dind-${container_name}"
   dind::ensure-network
   dind::ensure-volume ${reuse_volume} "${volume_name}"
+  dind::ensure-nat
+  dind::ensure-dns
 
   # TODO: create named volume for binaries and mount it to /k8s
   # in case of the source build
@@ -483,7 +597,18 @@ function dind::kubeadm {
 
 function dind::configure-kubectl {
   dind::step "Setting cluster config"
-  "${kubectl}" config set-cluster dind --server="http://localhost:${APISERVER_PORT}" --insecure-skip-tls-verify=true
+  local host="${dind_ip_base}2"
+  if [[ ${IP_MODE} = "ipv6" ]]; then
+      host="[${host}]"
+  fi
+  if [[ "${GCE_HOSTED}" = true ]]; then
+    if [[ "${IP_MODE}" = "ipv4" ]]; then
+      host="localhost"
+    else
+      host="[::1]"
+    fi
+  fi
+  "${kubectl}" config set-cluster dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
   "${kubectl}" config set-context dind --cluster=dind
   "${kubectl}" config use-context dind
 }
@@ -541,9 +666,11 @@ function dind::at-least-kubeadm-1-8 {
 function dind::init {
   local -a opts
   dind::set-master-opts
-  local master_ip="${dind_ip_base}.2"
-  local container_id=$(dind::run kube-master "${master_ip}" 1 127.0.0.1:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
-  local -a init_args
+  local local_host="127.0.0.1"
+  if [[ ${IP_MODE} = "ipv6" ]]; then
+      local_host="[::1]"
+  fi
+  local container_id=$(dind::run kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -553,14 +680,29 @@ function dind::init {
     # insecure-bind-address and insecure-bind-port are also overridden by patching
     # apiserver static pod, but someday when k-d-c will only support
     # kubeadm 1.8+ we'll be able to remove that patching
+    local pod_net_cidr=""
+    # TODO: May want to specify each of the plugins that require --pod-network-cidr
+    if [[ ${CNI_PLUGIN} != "bridge" ]]; then
+      pod_net_cidr="podSubnet: \"${POD_NETWORK_CIDR}\""$'\n'"  "
+    fi
+    local bind_address="0.0.0.0"
+    if [[ ${IP_MODE} = "ipv6" ]]; then
+	bind_address="::"
+    fi
     docker exec -i kube-master /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
 apiVersion: kubeadm.k8s.io/v1alpha1
-kind: MasterConfiguration
 unifiedControlPlaneImage: mirantis/hypokube:final
+kind: MasterConfiguration
+api:
+  advertiseAddress: "${kube_master_ip}"
+kubeProxy:
+  bindAddress: "${bind_address}"
 networking:
-  podSubnet: "${POD_NETWORK_CIDR}"
+  ${pod_net_cidr}serviceSubnet: "${SERVICE_CIDR}"
+tokenTTL: 0s
+nodeName: kube-master
 apiServerExtraArgs:
-  insecure-bind-address: "0.0.0.0"
+  insecure-bind-address: "${bind_address}"
   insecure-port: "8080"
 EOF
     init_args=(--config /etc/kubeadm.conf)
@@ -582,7 +724,7 @@ function dind::create-node-container {
   # kube-node-1 hostname, if there are two nodes, we should pick
   # kube-node-2 and so on
   local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
-  local node_ip="${dind_ip_base}.$((next_node_index + 2))"
+  local node_ip="${dind_ip_base}$((next_node_index + 2))"
   local -a opts
   if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
     opts+=(-v dind-k8s-binaries:/k8s)
@@ -603,7 +745,7 @@ function dind::join {
 }
 
 function dind::escape-e2e-name {
-    sed 's/[]\$*.^|()[]/\\&/g; s/\s\+/\\s+/g' <<< "$1" | tr -d '\n'
+    sed 's/[]\$*.^()[]/\\&/g; s/\s\+/\\s+/g' <<< "$1" | tr -d '\n'
 }
 
 function dind::accelerate-kube-dns {
@@ -680,13 +822,16 @@ function dind::wait-for-ready {
   echo "[done]" >&2
 
   "${kubectl}" get nodes >&2
-  dind::step "Access dashboard at:" "http://localhost:${APISERVER_PORT}/ui"
+  local_host="localhost"
+  if [[ ${IP_MODE} = "ipv6" ]]; then
+      local_host="[::1]"
+  fi
+  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/ui"
 }
 
 function dind::up {
   dind::down
   dind::init
-  local master_ip="$(docker inspect --format="{{.NetworkSettings.IPAddress}}" kube-master)"
   # pre-create node containers sequentially so they get predictable IPs
   local -a node_containers
   for ((n=1; n <= NUM_NODES; n++)); do
@@ -784,7 +929,6 @@ function dind::restore_container {
 }
 
 function dind::restore {
-  local master_ip="${dind_ip_base}.2"
   dind::down
   dind::step "Restoring master container"
   dind::set-master-opts
@@ -792,7 +936,11 @@ function dind::restore {
     (
       if [[ n -eq 0 ]]; then
         dind::step "Restoring master container"
-        dind::restore_container "$(dind::run -r kube-master "${master_ip}" 1 127.0.0.1:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
+        local local_host="127.0.0.1"
+        if [[ ${IP_MODE} = "ipv6" ]]; then
+          local_host="[::1]"
+        fi
+        dind::restore_container "$(dind::run -r kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -846,8 +994,12 @@ function dind::do-run-e2e {
   local parallel="${1:-}"
   local focus="${2:-}"
   local skip="${3:-}"
+  local host="${kube_master_ip}"
+  if [[ "${IP_MODE}" = "ipv6" ]]; then
+      host="[$host]"
+  fi
   dind::need-source
-  local test_args="--host=http://localhost:${APISERVER_PORT}"
+  local test_args="--host=http://${host}:${APISERVER_PORT}"
   local -a e2e_volume_opts=()
   local term=
   if [[ ${focus} ]]; then
@@ -865,21 +1017,21 @@ function dind::do-run-e2e {
   dind::set-build-volume-args
   if [ -t 1 ] ; then
     term="-it"
-    test_args="--ginkgo.noColor ${test_args}"
+    test_args="--ginkgo.noColor --num-nodes=2 ${test_args}"
   fi
   docker run \
          --rm ${term} \
          --net=host \
          "${build_volume_args[@]}" \
          -e KUBERNETES_PROVIDER=dind \
-         -e KUBE_MASTER_IP=http://localhost:${APISERVER_PORT} \
+         -e KUBE_MASTER_IP=http://${host}:${APISERVER_PORT} \
          -e KUBE_MASTER=local \
          -e KUBERNETES_CONFORMANCE_TEST=y \
          -e GINKGO_PARALLEL=${parallel} \
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://localhost:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
          go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
@@ -896,7 +1048,8 @@ function dind::clean {
 
 function dind::run-e2e {
   local focus="${1:-}"
-  local skip="${2:-\[Serial\]}"
+  local skip="${2:-[Serial]}"
+  skip="$(dind::escape-e2e-name "${skip}")"
   if [[ "$focus" ]]; then
     focus="$(dind::escape-e2e-name "${focus}")"
   else
@@ -912,6 +1065,7 @@ function dind::run-e2e {
 function dind::run-e2e-serial {
   local focus="${1:-}"
   local skip="${2:-}"
+  skip="$(dind::escape-e2e-name "${skip}")"
   dind::need-source
   if [[ "$focus" ]]; then
     focus="$(dind::escape-e2e-name "${focus}")"

--- a/gce-setup-local.sh
+++ b/gce-setup-local.sh
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -x
+
 if [ $(uname) = Darwin ]; then
   readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
 else
@@ -29,6 +31,7 @@ fi
 
 set -x
 KUBE_DIND_VM="${KUBE_DIND_VM:-k8s-dind}"
+export GCE_HOSTED=true
 export KUBE_RSYNC_PORT=8730
 export APISERVER_PORT=8899
 IP_MODE="${IP_MODE:-ipv4}"
@@ -51,5 +54,11 @@ docker-machine create \
                ${KUBE_DIND_VM}
 eval $(docker-machine env ${KUBE_DIND_VM})
 docker-machine ssh ${KUBE_DIND_VM} ${opts[*]} -N&
+if [ ! -z "${DIND_IMAGE:-}" ]; then
+    place=`pwd`
+    cd "${DIND_ROOT}"
+    build/build-local.sh
+    cd "$place"
+fi
 time "${DIND_ROOT}"/dind-cluster.sh up
 set +x

--- a/image/dindnet
+++ b/image/dindnet
@@ -18,51 +18,108 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-IP_CIDR=$(ip addr show eth0 | grep -w inet | awk '{ print $2; }')
-IP=$(echo $IP_CIDR | sed 's,/.*,,')
+
+first_time=true
+
+function get_ipv4_info {
+  local from_intf=$1
+  IPV4_CIDR=$(ip addr show $from_intf | grep -w inet | awk '{ print $2; }')
+  IPV4="$(echo ${IPV4_CIDR} | sed 's,/.*,,')"
+  DEFAULT_GW="$(ip route | grep default | cut -f 3 -d" ")"
+}
+
+function get_ipv6_info {
+  local from_intf=$1
+  IPV6_CIDR="$(ip addr show $from_intf | grep -w inet6 | grep -i global | head -1 | awk '{ print $2; }')"
+  IPV6="$(echo ${IPV6_CIDR} | sed 's,/.*,,')"
+  DEFAULT_GW="$(ip -6 route | grep default | cut -f 3 -d" ")"
+}
 
 function dind::setup-bridge {
+  if [[ ! -z "$(ip addr show dind0 2>/dev/null)" ]]; then
+    if [[ "${IP_MODE}" = "ipv6" ]]; then
+      get_ipv6_info dind0
+    else
+      get_ipv4_info dind0
+    fi
+    first_time=false
+    return  # Bridge is already set up
+  fi
+
+  get_ipv4_info eth0
+
   # create dind0 bridge and attach it to the veth interface eth0
   brctl addbr dind0
   brctl addif dind0 eth0
   ip link set dind0 up
+
+  # Note: default route will be removed, when delete IPv4 address
+  ip addr del ${IPV4_CIDR} dev eth0
+  ip addr add ${IPV4_CIDR} dev dind0
+  ip route add default via ${DEFAULT_GW} dev dind0
+  if [[ "${IP_MODE}" = "ipv6" ]]; then
+    get_ipv6_info eth0
+    ip addr del ${IPV6_CIDR} dev eth0
+    ip addr add ${IPV6_CIDR} dev dind0
+    if [[ ! -z "${DEFAULT_GW}" ]]; then
+      # Must remove old route first (not deleted, when delete IP off of eth0, like with V4)
+      ip -6 route del default via ${DEFAULT_GW} dev eth0
+      ip -6 route add default via ${DEFAULT_GW} dev dind0
+    fi
+    ip -6 route add ${DNS64_PREFIX_CIDR} via ${LOCAL_NAT64_SERVER}
+  fi
+  echo "Bridge dind0 set up and IPs/routes adjusted."
+}
+
+function dind::setup-config-file {
+  if [[ "${IP_MODE}" = "ipv6" ]]; then
+    INSTANCE=`hostname | cut -d"-" -f 3`
+    if [[ "${INSTANCE}" = "" ]]; then
+      INSTANCE="10"
+    fi
+    echo "Instance: ${INSTANCE}"
+
+    # FUTURE: Handle dual-stack mode
   
-  # move ip to the bridge and restore routing via the old gateway
-  NETWORK_SIZE=$(echo $IP_CIDR | sed 's,.*/,,')
-  DEFAULT_ROUTE=$(ip route | grep default | sed 's/eth0/dind0/')
-  DEFAULT_GW=$(echo $DEFAULT_ROUTE|awk '{print $3;}')
+    NETWORK="$(echo $DEFAULT_GW | sed 's/[:][^:]*$/:/')"
+    NETWORK_SIZE="$(echo ${IPV6_CIDR} | sed 's,.*/,,')"
+    # Will use /80 for pod network
+    HOST_MIN="${POD_NET_PREFIX}:${INSTANCE}::1"
+    HOST_MAX="${POD_NET_PREFIX}:${INSTANCE}:ffff:ffff:ffff"
+    DEFAULT_ROUTE="::/0"
+  else
+    # compute a network for the containers to live in
+    # by adding CNI_BRIDGE_NETWORK_OFFSET to the current IP and cutting off
+    # non-network bits according to CNI_BRIDGE_NETWORK_SIZE
+    CNI_BRIDGE_NETWORK_SIZE="${CNI_BRIDGE_NETWORK_SIZE:-24}"
+    NETWORK="$(ip route | grep dind0 | grep -v default | sed 's,/.*,,')"
+    NETWORK_SIZE="$(echo ${IPV4_CIDR} | sed 's,.*/,,')"
   
-  ip addr del $IP_CIDR dev eth0
-  ip addr add $IP_CIDR dev dind0
-  ip route add $DEFAULT_ROUTE
+    WILDCARD=$(ipcalc ${IPV4_CIDR} | grep Wildcard | awk '{print $2;}')
+    IFS=. read -r i1 i2 i3 i4 <<< ${IPV4}
+    IFS=. read -r n1 n2 n3 n4 <<< ${NETWORK}
+    IFS=. read -r o1 o2 o3 o4 <<< ${CNI_BRIDGE_NETWORK_OFFSET}
+    IFS=. read -r w1 w2 w3 w4 <<< ${WILDCARD}
   
-  # compute a network for the containers to live in
-  # by adding CNI_BRIDGE_NETWORK_OFFSET to the current IP and cutting off
-  # non-network bits according to CNI_BRIDGE_NETWORK_SIZE
-  CNI_BRIDGE_NETWORK_SIZE=${CNI_BRIDGE_NETWORK_SIZE:-24}
-  NETWORK=$(ip route | grep dind0 | grep -v default | sed 's,/.*,,')
+    IP_PLUS_OFFSET=$(printf "%d.%d.%d.%d\n" \
+                            "$(( n1 + ((i1 - n1 + o1) & w1) ))" \
+                            "$(( n2 + ((i2 - n2 + o2) & w2) ))" \
+                            "$(( n3 + ((i3 - n3 + o3) & w3) ))" \
+                            "$(( n4 + ((i4 - n4 + o4) & w4) ))")
   
-  WILDCARD=$(ipcalc $IP_CIDR | grep Wildcard | awk '{print $2;}')
-  IFS=. read -r i1 i2 i3 i4 <<< ${IP}
-  IFS=. read -r n1 n2 n3 n4 <<< ${NETWORK}
-  IFS=. read -r o1 o2 o3 o4 <<< ${CNI_BRIDGE_NETWORK_OFFSET}
-  IFS=. read -r w1 w2 w3 w4 <<< ${WILDCARD}
-  
-  IP_PLUS_OFFSET=$(printf "%d.%d.%d.%d\n" \
-                          "$(( n1 + ((i1 - n1 + o1) & w1) ))" \
-                          "$(( n2 + ((i2 - n2 + o2) & w2) ))" \
-                          "$(( n3 + ((i3 - n3 + o3) & w3) ))" \
-                          "$(( n4 + ((i4 - n4 + o4) & w4) ))")
-  
-  HOST_MIN=$(ipcalc $IP_PLUS_OFFSET/$CNI_BRIDGE_NETWORK_SIZE | grep HostMin | awk '{print $2;}')
-  HOST_MAX=$(ipcalc $IP_PLUS_OFFSET/$CNI_BRIDGE_NETWORK_SIZE | grep HostMax | awk '{print $2;}')
+    HOST_MIN=$(ipcalc ${IP_PLUS_OFFSET}/${CNI_BRIDGE_NETWORK_SIZE} | grep HostMin | awk '{print $2;}')
+    HOST_MAX=$(ipcalc ${IP_PLUS_OFFSET}/${CNI_BRIDGE_NETWORK_SIZE} | grep HostMax | awk '{print $2;}')
+    DEFAULT_ROUTE="0.0.0.0/0"
+  fi
   echo "Using ${HOST_MIN} .. ${HOST_MAX} for docker containers"
-  
-  cat >/etc/cni/net.d/cni.conf <<EOF
+  CONFIG_FILE="/etc/cni/net.d/cni.conf"
+  cat >${CONFIG_FILE} <<CFG_PREFIX_EOF
 {
+    "cniVersion": "0.3.0",
     "name": "dindnet",
     "type": "bridge",
     "bridge": "dind0",
+    "hairpinMode": true,
     "ipam": {
         "type": "host-local",
         "subnet": "${NETWORK}/${NETWORK_SIZE}",
@@ -70,29 +127,87 @@ function dind::setup-bridge {
         "rangeEnd": "${HOST_MAX}",
         "gateway": "${DEFAULT_GW}",
         "routes": [
-            { "dst": "0.0.0.0/0" }
+CFG_PREFIX_EOF
+  if [[ "${IP_MODE}" = "ipv6" ]]; then
+      cat >>${CONFIG_FILE} <<CFG_IPV6_EOF
+            { "dst": "${DNS64_PREFIX_CIDR}", "gw": "${LOCAL_NAT64_SERVER}"},
+CFG_IPV6_EOF
+  fi
+  cat >>${CONFIG_FILE} <<CFG_SUFFIX_EOF
+            { "dst": "${DEFAULT_ROUTE}" }
         ]
     }
 }
-EOF
+CFG_SUFFIX_EOF
+  echo "Config file created: ${CONFIG_FILE}"
 }
 
+function dind::make-kubelet-extra-dns-args {
+    if [[ "${IP_MODE}" = "ipv6" ]]; then
+	# Create drop-in file here, where we know the DNS IP.
+	mkdir -p /etc/systemd/system/kubelet.service.d
+	cat >/etc/systemd/system/kubelet.service.d/20-extra-dns-args.conf <<EOF
+[Service]
+Environment="KUBELET_DNS_ARGS=--cluster-dns=${DNS_SVC_IP} --cluster-domain=cluster.local"
+EOF
+	echo "Using DNS ${DNS_SVC_IP} for kubelet in IPv6 mode"
+    fi
+}
+
+
+# ******************** START ********************
 if [[ "${CNI_BRIDGE_NETWORK_OFFSET:-}" ]]; then
-   dind::setup-bridge
+  dind::setup-bridge
+  # TODO: Remove, once DinD is able to use v0.6.0 CNI release
+  protocol=""
+  if [[ "${IP_MODE}" = "ipv6" ]]; then
+      protocol="-6"
+  fi
+  curl -sSL ${protocol} --retry 5 https://github.com/containernetworking/plugins/releases/download/v0.6.0/cni-plugins-amd64-v0.6.0.tgz | \
+      tar -C /opt/cni/bin -xz
+  echo "Installed CNI v0.6.0"
+  dind::setup-config-file
+  dind::make-kubelet-extra-dns-args
+else
+  get_ipv4_info eth0
 fi
 
-# make docker's kube-dns friendly
-old_ns="$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf)"
-if [[ ${old_ns} ]]; then
-  # sed -i doesn't work here because of docker's handling of /etc/resolv.conf
-  sed "s/^nameserver.*/nameserver ${IP}/" /etc/resolv.conf >/etc/resolv.conf.updated
-  cat /etc/resolv.conf.updated >/etc/resolv.conf
-  # rm /tmp/resolv.conf.updated
+if [[ "${IP_MODE}" = "ipv6" ]]; then
+  if [[ "$first_time" = true ]]; then
+    sed -e "s/^${IPV4}/${IPV6}/g" /etc/hosts > /etc/hosts.updated
+    cp /etc/hosts /etc/hosts.orig
+    cat /etc/hosts.updated >/etc/hosts
+    # Removed embedded docker DNS, as we'll only be using IPv6, which is already in resolv.conf
+    sed "s/^nameserver.*127\.0\.0\.11/# Removed 127.0.0.11/" /etc/resolv.conf >/etc/resolv.conf.updated
+    cp /etc/resolv.conf /etc/resolv.conf.orig
+    cat /etc/resolv.conf.updated >/etc/resolv.conf
+    echo "Host and DNS info updated"
+  fi
+  echo "Setup completed for IPv6"
+  set +x
   while true; do
-    socat udp4-recvfrom:53,reuseaddr,fork,bind=${IP} UDP:${old_ns}:53 || true
-    echo "WARNING: restarting socat" >&2
+      sleep 1  # Keep service running, so actions not attempted multiple times
   done
 else
-  echo "WARNING: couldn't get nameserver" >&2
-  exit 1  
+  if [[ "$first_time" = true ]]; then
+    # make docker's kube-dns friendly
+    old_ns="$(awk '/^nameserver/ {print $2; exit}' /etc/resolv.conf)"
+    if [[ ${old_ns} ]]; then
+      # sed -i doesn't work here because of docker's handling of /etc/resolv.conf
+      sed "s/^nameserver.*/nameserver ${IPV4}/" /etc/resolv.conf >/etc/resolv.conf.updated
+      cp /etc/resolv.conf /etc/resolv.conf.orig
+      cat /etc/resolv.conf.updated >/etc/resolv.conf
+    else
+      echo "WARNING: couldn't get nameserver" >&2
+      exit 1
+    fi
+  else
+    # Already switched from built-in DNS server, so use original value for socat 
+    old_ns="127.0.0.11"
+  fi
+  echo "Setup completed for IPv4"
+  while true; do
+    socat udp4-recvfrom:53,reuseaddr,fork,bind=${IPV4} UDP:${old_ns}:53 || true
+    echo "WARNING: restarting socat" >&2
+  done
 fi

--- a/image/rundocker
+++ b/image/rundocker
@@ -27,4 +27,13 @@ if grep -q '[[:blank:]]overlay[[:blank:]]*' /proc/filesystems; then
     storage_opts="--storage-driver=overlay2 --storage-opt overlay2.override_kernel_check=true"
 fi
 
+# FIXME: this fix really concerns kubelet, so perhaps it should go
+# into another place
+# Kubelet will try to contact GCE metadata server on startup if
+# it detects a GCE VM and this breaks kdc on Travis
+if [[ $(cat /sys/class/dmi/id/product_name) =~ Google ]]; then
+    echo "KDC" >/dmi_product_name
+    mount --bind /dmi_product_name /sys/class/dmi/id/product_name
+fi
+
 exec /usr/bin/dockerd -H fd:// ${storage_opts} -g /dind/docker "$@"

--- a/image/snapshot
+++ b/image/snapshot
@@ -50,8 +50,7 @@ function snapshot::prepare {
     while kubectl get pod kube-controller-manager-kube-master -n kube-system -o name 2>/dev/null | grep -q pods*/; do
       if ((--n == 0)); then
         echo "WARNING: kubelet glitch: kube-controller-manager won't stop; pods may 'blink' for some time after restore" >&2
-        systemctl stop kubelet docker
-        return
+        break
       fi
       sleep 0.3
     done
@@ -62,8 +61,7 @@ function snapshot::prepare {
     while kubectl get pod -n kube-system -o name -l k8s-app=kube-proxy | grep -q '^pods*/'; do
       if ((--n == 0)); then
         echo "WARNING: cluster glitch: proxy pods aren't removed; pods may 'blink' for some time after restore" >&2
-        systemctl stop kubelet docker
-        return
+        break
       fi
       sleep 0.3
     done

--- a/image/snapshot
+++ b/image/snapshot
@@ -18,13 +18,21 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+function snapshot::retry {
+  # based on retry function in hack/jenkins/ scripts in k8s source
+  for i in {1..10}; do
+    "$@" && return 0 || sleep ${i}
+  done
+  "$@"
+}
+
 function snapshot::prepare {
   if [[ -f /etc/kubernetes/manifests/kube-controller-manager.json || -f /etc/kubernetes/manifests/kube-controller-manager.yaml ]]; then
     # remove kube-dns and kube-dashboard pods to avoid 'blinking'
     # FIXME: when using k8s 1.6 kube-dns pods stay in 'Terminating' state
     # Possibly related: https://github.com/kubernetes/kubernetes/issues/42685
-    kubectl scale deployment --replicas=0 -n kube-system kube-dns
-    kubectl scale deployment --replicas=0 -n kube-system kubernetes-dashboard
+    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kube-dns
+    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kubernetes-dashboard
     local n=60
     while kubectl get pods -n kube-system -o name | egrep -q '^pods*/(kube-dns-|kubernetes-dashboard-)'; do
       if ((--n == 0)); then
@@ -49,7 +57,7 @@ function snapshot::prepare {
     done
 
     # delete proxy pods so they don't "blink" after cluster restart
-    kubectl delete pod --now -l k8s-app=kube-proxy -n kube-system 2>/dev/null
+    snapshot::retry kubectl delete pod --now -l k8s-app=kube-proxy -n kube-system 2>/dev/null
     n=40
     while kubectl get pod -n kube-system -o name -l k8s-app=kube-proxy | grep -q '^pods*/'; do
       if ((--n == 0)); then
@@ -59,7 +67,7 @@ function snapshot::prepare {
       fi
       sleep 0.3
     done
-    kubectl get pods -n kube-system
+    snapshot::retry kubectl get pods -n kube-system
     systemctl stop kubelet docker
     # now it's safe to put back the manifest
     mv /manifests.bak/* /etc/kubernetes/manifests/

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -18,6 +18,7 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE:-keep://}"
 KUBEADM_SOURCE="${KUBEADM_SOURCE:-keep://}"
 
@@ -294,7 +295,6 @@ function dind::set-kubelet-extra-args {
 [Service]
 Environment="KUBELET_EXTRA_ARGS=${kubelet_extra_args[@]} --v=4"
 EOF
-    systemctl daemon-reload
   fi
 }
 
@@ -307,7 +307,12 @@ function dind::prepare-for-kubeadm {
   fi
   dind::ensure-binaries-and-hypokube
 
+  # Ensure that DNS drop-in is created
+  systemctl start dindnet
+
   dind::set-kubelet-extra-args
+
+  systemctl daemon-reload
 
   # enable kubelet right before starting kubeadm to avoid
   # longer delays between container restarts

--- a/test.sh
+++ b/test.sh
@@ -257,6 +257,10 @@ function test-case-src-master-weave {
   )
 }
 
+function test-case-src-working-area {
+  test-cluster-src
+}
+
 if [[ ! ${TEST_CASE} ]]; then
   test-case-1.6
   test-case-1.6-flannel


### PR DESCRIPTION
Adding a WIP change (on top of the fix-1.8+ branch) that will allow DinD to be used on an IPv6 only Kubernetes cluster.

This uses IPv6 addresses for all pods, and makes use of DNS64 and NAT64 containers, to convert external IPs to IPv4 embedded IPv6 addresses.

An IP_MODE environment variable is added to select between IPv4 (default) and IPv6. Additional environment variables can be set to customize DinD subnet, service subnet CIDR, and prefix to use for DNS64.

To use, must use the customer Kubernetes repo in the README.md, as it has IPv6 patches that are in-flight (or fixing bugs).

Notes:
- Uses /80 for pod subnet size.
- Requires building local copy, due to changes to DinD code.
- All pod subnets are "inside" of the DinD /64 subnet (same as what IPv4 does).
- Includes fix to restore controller manifest, when failure to shutdown controller/proxy pods during snapshot.
- Relies on both a custom Kubernetes repo (until commits are upstreamed), and kube-dns image (referenced in manifest of custom Kubernetes repo).
- Could be customized to use NAT66 container as an option to allow access to external IPv6 IPs.
- Future could add dual-stack support.
