### PR TITLE
Allow customization of DIND_SUBNET

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,9 +1,9 @@
 if [[ ${IP_MODE} = "ipv4" ]]; then
     # DinD subnet (expected to be /16)
-    DIND_SUBNET="10.192.0.0"
+    DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
 else
     # DinD subnet (expected to be /64)
-    DIND_SUBNET="fd00:10::"
+    DIND_SUBNET="${DIND_SUBNET:-fd00:10::}"
 fi
 
 # Apiserver port


### PR DESCRIPTION
Currently, to custmize DIND_SUBNET, one has to set EMBEDDED_CONFIG
and then also manually set DIND_IMAGE to a default value. This
change just lets the developer customize DIND_SUBNET, w/o having to
disable the other defaults that are set.