### PR TITLE
add support for CoreDNS as DNS service of k8s

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -56,3 +56,8 @@ CNI_PLUGIN="${CNI_PLUGIN:-bridge}"
 # Any options to be passed to the docker run both on init and reup.
 # By default it's empty
 # MASTER_EXTRA_OPTS="  "
+
+# Define which DNS service to run
+# possible values are kube-dns (default) and coredns
+DNS_SERVICE=${DNS_SERVICE:-kube-dns}
+

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -530,6 +530,7 @@ function dind::run {
       args+=("systemd.setenv=POD_NET_PREFIX=${POD_NET_PREFIX}")
   fi
   args+=("systemd.setenv=DNS_SVC_IP=${DNS_SVC_IP}")
+  args+=("systemd.setenv=DNS_SERVICE=${DNS_SERVICE}")
   if [[ ! "${container_name}" ]]; then
     echo >&2 "Must specify container name"
     exit 1
@@ -565,7 +566,7 @@ function dind::run {
 
   # Start the new container.
   docker run \
-	 -e IP_MODE="${IP_MODE}" \
+         -e IP_MODE="${IP_MODE}" \
          -d --privileged \
          --net kubeadm-dind-net \
          --name "${container_name}" \
@@ -724,6 +725,13 @@ apiServerExtraArgs:
   insecure-bind-address: "${bind_address}"
   insecure-port: "8080"
 EOF
+    if [[ ${DNS_SERVICE} == "coredns" ]]; then
+      docker exec -i kube-master /bin/sh -c "cat >>/etc/kubeadm.conf" <<EOF
+featureGates:
+  CoreDNS: true 
+
+EOF
+    fi
     init_args=(--config /etc/kubeadm.conf)
   else
     init_args=(--pod-network-cidr="${POD_NETWORK_CIDR}")
@@ -767,11 +775,13 @@ function dind::escape-e2e-name {
 }
 
 function dind::accelerate-kube-dns {
-  dind::step "Patching kube-dns deployment to make it start faster"
-  # Could do this on the host, too, but we don't want to require jq here
-  # TODO: do this in wrapkubeadm
-  docker exec kube-master /bin/bash -c \
-         "kubectl get deployment kube-dns -n kube-system -o json | jq '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds = 3|.spec.template.spec.containers[0].readinessProbe.periodSeconds = 3' | kubectl apply --force -f -"
+  if [[ ${DNS_SERVICE} == "kube-dns" ]]; then
+     dind::step "Patching kube-dns deployment to make it start faster"
+     # Could do this on the host, too, but we don't want to require jq here
+     # TODO: do this in wrapkubeadm
+     docker exec kube-master /bin/bash -c \
+        "kubectl get deployment kube-dns -n kube-system -o json | jq '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds = 3|.spec.template.spec.containers[0].readinessProbe.periodSeconds = 3' | kubectl apply --force -f -"
+ fi
 }
 
 function dind::component-ready {
@@ -834,7 +844,7 @@ function dind::wait-for-ready {
 
   dind::step "Bringing up kube-dns and kubernetes-dashboard"
   # on Travis 'scale' sometimes fails with 'error: Scaling the resource failed with: etcdserver: request timed out; Current resource version 442' here
-  dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system kube-dns
+  dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system -l k8s-app=kube-dns
   dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system kubernetes-dashboard
 
   ntries=200

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -844,7 +844,7 @@ function dind::wait-for-ready {
 
   dind::step "Bringing up kube-dns and kubernetes-dashboard"
   # on Travis 'scale' sometimes fails with 'error: Scaling the resource failed with: etcdserver: request timed out; Current resource version 442' here
-  dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system -l k8s-app=kube-dns
+  dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system ${DNS_SERVICE}
   dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system kubernetes-dashboard
 
   ntries=200

--- a/image/snapshot
+++ b/image/snapshot
@@ -31,10 +31,10 @@ function snapshot::prepare {
     # remove kube-dns and kube-dashboard pods to avoid 'blinking'
     # FIXME: when using k8s 1.6 kube-dns pods stay in 'Terminating' state
     # Possibly related: https://github.com/kubernetes/kubernetes/issues/42685
-    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kube-dns
+    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system -l k8s-app=kube-dns
     snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kubernetes-dashboard
     local n=60
-    while kubectl get pods -n kube-system -o name | egrep -q '^pods*/(kube-dns-|kubernetes-dashboard-)'; do
+    while kubectl get pods -n kube-system -o name | egrep -q '^pods*/(${DNS_SERVICE}-|kubernetes-dashboard-)'; do
       if ((--n == 0)); then
         echo "WARNING: controller manager glitch: dns & dashboard won't stop; pods may 'blink' for some time after restore" >&2
         systemctl stop kubelet docker

--- a/image/snapshot
+++ b/image/snapshot
@@ -27,10 +27,18 @@ function snapshot::retry {
 }
 
 function snapshot::prepare {
+
+
   if [[ -f /etc/kubernetes/manifests/kube-controller-manager.json || -f /etc/kubernetes/manifests/kube-controller-manager.yaml ]]; then
     # remove kube-dns and kube-dashboard pods to avoid 'blinking'
     # FIXME: when using k8s 1.6 kube-dns pods stay in 'Terminating' state
     # Possibly related: https://github.com/kubernetes/kubernetes/issues/42685
+
+    if [[ -n `kubectl get deployment -n kube-system coredns` ]]; then
+      DNS_SERVICE=coredns
+    else
+      DNS_SERVICE=kube-dns
+    fi
     snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${DNS_SERVICE}
     snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kubernetes-dashboard
     local n=60

--- a/image/snapshot
+++ b/image/snapshot
@@ -31,7 +31,7 @@ function snapshot::prepare {
     # remove kube-dns and kube-dashboard pods to avoid 'blinking'
     # FIXME: when using k8s 1.6 kube-dns pods stay in 'Terminating' state
     # Possibly related: https://github.com/kubernetes/kubernetes/issues/42685
-    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system -l k8s-app=kube-dns
+    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${DNS_SERVICE}
     snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kubernetes-dashboard
     local n=60
     while kubectl get pods -n kube-system -o name | egrep -q '^pods*/(${DNS_SERVICE}-|kubernetes-dashboard-)'; do

--- a/test.sh
+++ b/test.sh
@@ -272,6 +272,14 @@ function test-case-src-working-area {
   test-cluster-src
 }
 
+function test-case-src-master-coredns {
+  (
+    export DNS_SERVICE=coredns
+    test-cluster-src
+  )
+}
+
+
 if [[ ! ${TEST_CASE} ]]; then
   test-case-1.6
   test-case-1.6-flannel
@@ -293,6 +301,7 @@ if [[ ! ${TEST_CASE} ]]; then
   # test-case-src-master-calico
   # test-case-src-calico-kdd
   # test-case-src-master-weave
+  # test-case-src-master-coredns
 else
   "test-case-${TEST_CASE}"
 fi


### PR DESCRIPTION
# Subject : add support for CoreDNS.

# High level
CoreDNS is now deployable in kubeadm within the "feature-gates" option.
The aim is to replace kube-dns as the DNS server in kubernetes cluster.

My target was to use kubeadm-dind-cluster to setup an Ipv6 cluster and be able to validate that CroeDNS can run in Ipv6 only environment.

# Added in this changelist

1. Add DNS_SERVICE shell variable
2. Add needed "FeatureGates" option to kubeadm config if CoreDNS is selected
3. Change monitoring of DNS to be compatible for both kube-dns and CoreDNS



