### PR TITLE
Create Multiple Clusters on the same Docker Daemon

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -39,6 +39,12 @@ DIND_IMAGE="${DIND_IMAGE:-mirantis/kubeadm-dind-cluster:v1.8}"
 # DIND containers together.
 CNI_PLUGIN="${CNI_PLUGIN:-bridge}"
 
+# Name Prefix for all docker resources related to the cluster we're operating on
+# This allows you to run multiple clusters on the same docker daemon
+#   ie: "CLUSTER_PREFIX=test" --> test-kube-master, test-kube-node-1, test-kubeadm-dind-net
+# Use together with APISERVER_PORT and DIND_SUBNET to prevent network conflicts
+# CLUSTER_PREFIX="${CLUSTER_PREFIX:-test}"
+
 # When using Calico with Kubernetes as the datastore (calico-kdd) your
 # controller manager needs to be started with `--cluster-cidr=192.168.0.0/16`.
 # More information here: http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -57,6 +57,12 @@ fi
 POD_NETWORK_CIDR="${POD_NETWORK_CIDR:-${DEFAULT_POD_NETWORK_CIDR}}"
 ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
 GCE_HOSTED="${GCE_HOSTED:-false}"
+
+if [[ "${CLUSTER_PREFIX:-}" ]]; then
+  CLUSTER_PREFIX="${CLUSTER_PREFIX:-}-" # auto-delimit the prefix /w a hyphen
+else
+  CLUSTER_PREFIX=""
+fi
 if [[ ${IP_MODE} = "ipv6" ]]; then
     DIND_SUBNET="${DIND_SUBNET:-fd00:10::}"
     dind_ip_base="${DIND_SUBNET}"
@@ -181,7 +187,7 @@ function dind::volume-exists {
 
 function dind::create-volume {
   local name="$1"
-  docker volume create --label mirantis.kubeadm_dind_cluster --name "${name}" >/dev/null
+  docker volume create --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster --name "${name}" >/dev/null
 }
 
 # We mount /boot and /lib/modules into the container
@@ -417,13 +423,13 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect kubeadm-dind-net >&/dev/null; then
+  if ! docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" kubeadm-dind-net >/dev/null
+    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" "${CLUSTER_PREFIX}kubeadm-dind-net" >/dev/null
   fi
 }
 
@@ -472,7 +478,7 @@ BIND9_EOF
 		docker-machine ssh k8s-dind sudo mkdir -p ${bind9_path}/conf ${bind9_path}/cache
 		docker-machine ssh k8s-dind sudo cp /home/docker-user/bind9-named.conf ${bind9_path}/conf/named.conf
 	    fi
-	    docker run -d --name bind9 --hostname bind9 --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+	    docker run -d --name bind9 --hostname bind9 --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip6 $dns_server --dns $dns_server \
 		   -v ${bind9_path}/conf/named.conf:/etc/bind/named.conf \
@@ -487,7 +493,7 @@ BIND9_EOF
 function dind::ensure-nat {
     if [[  ${IP_MODE} = "ipv6" ]]; then
         if ! docker ps | grep tayga >&/dev/null; then
-            docker run -d --name tayga --hostname tayga --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+            docker run -d --name tayga --hostname tayga --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip 172.18.0.200 --ip6 ${LOCAL_NAT64_SERVER} --dns ${REMOTE_DNS64_V4SERVER} --dns ${dns_server} \
 		   -e TAYGA_CONF_PREFIX=${DNS64_PREFIX_CIDR} -e TAYGA_CONF_IPV4_ADDR=172.18.0.200 \
@@ -573,10 +579,10 @@ function dind::run {
   docker run \
 	 -e IP_MODE="${IP_MODE}" \
          -d --privileged \
-         --net kubeadm-dind-net \
+         --net "${CLUSTER_PREFIX}kubeadm-dind-net" \
          --name "${container_name}" \
          --hostname "${container_name}" \
-         -l mirantis.kubeadm_dind_cluster \
+         -l mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
          -v ${volume_name}:/dind \
          ${opts[@]+"${opts[@]}"} \
          "${DIND_IMAGE}" \
@@ -621,9 +627,9 @@ function dind::configure-kubectl {
       host="[::1]"
     fi
   fi
-  "${kubectl}" config set-cluster dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
-  "${kubectl}" config set-context dind --cluster=dind
-  "${kubectl}" config use-context dind
+  "${kubectl}" config set-cluster ${CLUSTER_PREFIX}dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
+  "${kubectl}" config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind
+  "${kubectl}" config use-context ${CLUSTER_PREFIX}dind
 }
 
 force_make_binaries=
@@ -683,7 +689,7 @@ function dind::deploy-dashboard {
 function dind::at-least-kubeadm-1-8 {
   # kubeadm 1.6 and below doesn't support 'version -o short' and will
   # thus produce an empty string
-  local ver="$(docker exec kube-master kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
+  local ver="$(docker exec "${CLUSTER_PREFIX}kube-master" kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
   if [[ ! ${ver} || ${ver} = v1.7 ]]; then
     return 1
   fi
@@ -696,7 +702,7 @@ function dind::init {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  local container_id=$(dind::run kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
+  local container_id=$(dind::run "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -716,7 +722,7 @@ function dind::init {
       bind_address="::"
     fi
     dind::proxy kube-master
-    docker exec -i kube-master /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
+    docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
 apiVersion: kubeadm.k8s.io/v1alpha1
 unifiedControlPlaneImage: mirantis/hypokube:final
 kind: MasterConfiguration
@@ -726,7 +732,7 @@ api:
 networking:
   ${pod_net_cidr}serviceSubnet: "${SERVICE_CIDR}"
 tokenTTL: 0s
-nodeName: kube-master
+nodeName: ${CLUSTER_PREFIX}kube-master
 apiServerExtraArgs:
   insecure-bind-address: "${bind_address}"
   insecure-port: "8080"
@@ -746,9 +752,9 @@ function dind::create-node-container {
     shift
   fi
   # if there's just one node currently, it's master, thus we need to use
-  # kube-node-1 hostname, if there are two nodes, we should pick
-  # kube-node-2 and so on
-  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
+  # ${CLUSTER_PREFIX}kube-node-1 hostname, if there are two nodes, we should pick
+  # ${CLUSTER_PREFIX}kube-node-2 and so on
+  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
   local node_ip="${dind_ip_base}$((next_node_index + 2))"
   local -a opts
   if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
@@ -760,7 +766,7 @@ function dind::create-node-container {
       opts+=(-e HYPERKUBE_SOURCE=build://)
     fi
   fi
-  dind::run ${reuse_volume} kube-node-${next_node_index} ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
+  dind::run ${reuse_volume} "${CLUSTER_PREFIX}kube-node-${next_node_index}" ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
 }
 
 function dind::join {
@@ -778,7 +784,7 @@ function dind::accelerate-kube-dns {
   dind::step "Patching kube-dns deployment to make it start faster"
   # Could do this on the host, too, but we don't want to require jq here
   # TODO: do this in wrapkubeadm
-  docker exec kube-master /bin/bash -c \
+  docker exec "${CLUSTER_PREFIX}kube-master" /bin/bash -c \
          "kubectl get deployment kube-dns -n kube-system -o json | jq '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds = 3|.spec.template.spec.containers[0].readinessProbe.periodSeconds = 3' | kubectl apply --force -f -"
 }
 
@@ -902,7 +908,7 @@ function dind::up {
   else
     # FIXME: this may fail depending on k8s/kubeadm version
     # FIXME: check for taint & retry if it's there
-    "${kubectl}" taint nodes kube-master node-role.kubernetes.io/master- || true
+    "${kubectl}" taint nodes "${CLUSTER_PREFIX}kube-master" node-role.kubernetes.io/master- || true
   fi
   case "${CNI_PLUGIN}" in
     bridge)
@@ -944,9 +950,9 @@ function dind::snapshot_container {
 
 function dind::snapshot {
   dind::step "Taking snapshot of the cluster"
-  dind::snapshot_container kube-master
+  dind::snapshot_container "${CLUSTER_PREFIX}kube-master"
   for ((n=1; n <= NUM_NODES; n++)); do
-    dind::snapshot_container "kube-node-${n}"
+    dind::snapshot_container "${CLUSTER_PREFIX}kube-node-${n}"
   done
   dind::wait-for-ready
 }
@@ -969,7 +975,7 @@ function dind::restore {
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -994,26 +1000,26 @@ function dind::restore {
 }
 
 function dind::down {
-  docker ps -a -q --filter=label=mirantis.kubeadm_dind_cluster | while read container_id; do
+  docker ps -a -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | while read container_id; do
     dind::step "Removing container:" "${container_id}"
     docker rm -fv "${container_id}"
   done
 }
 
 function dind::remove-volumes {
-  # docker 1.13+: docker volume ls -q -f label=mirantis.kubeadm_dind_cluster
-  docker volume ls -q | (grep '^kubeadm-dind' || true) | while read volume_id; do
+  # docker 1.13+: docker volume ls -q -f label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster
+  docker volume ls -q | (grep "^kubeadm-dind-${CLUSTER_PREFIX}" || true) | while read volume_id; do
     dind::step "Removing volume:" "${volume_id}"
     docker volume rm "${volume_id}"
   done
 }
 
 function dind::check-for-snapshot {
-  if ! dind::volume-exists "kubeadm-dind-kube-master"; then
+  if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-master"; then
     return 1
   fi
   for ((n=1; n <= NUM_NODES; n++)); do
-    if ! dind::volume-exists "kubeadm-dind-kube-node-${n}"; then
+    if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-node-${n}"; then
       return 1
     fi
   done
@@ -1067,9 +1073,9 @@ function dind::do-run-e2e {
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
-         cluster/kubectl.sh config set-context dind --cluster=dind &&
-         cluster/kubectl.sh config use-context dind &&
+         bash -c "cluster/kubectl.sh config set-cluster ${CLUSTER_PREFIX}dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         cluster/kubectl.sh config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind &&
+         cluster/kubectl.sh config use-context ${CLUSTER_PREFIX}dind &&
          go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
 }
 
@@ -1077,8 +1083,8 @@ function dind::clean {
   dind::down
   # dind::remove-images
   dind::remove-volumes
-  if docker network inspect kubeadm-dind-net >&/dev/null; then
-    docker network rm kubeadm-dind-net
+  if docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
+    docker network rm "${CLUSTER_PREFIX}kubeadm-dind-net"
   fi
 }
 
@@ -1130,7 +1136,7 @@ function dind::step {
 function dind::dump {
   set +e
   echo "*** Dumping cluster state ***"
-  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.kubeadm_dind_cluster); do
+  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster); do
     for service in kubelet.service dindnet.service criproxy.service dockershim.service; do
       if docker exec "${node}" systemctl is-enabled "${service}" >&/dev/null; then
         echo "@@@ service-${node}-${service}.log @@@"
@@ -1147,23 +1153,23 @@ function dind::dump {
     echo "@@@ ip-r-${node}.txt @@@"
     docker exec "${node}" ip r
   done
-  docker exec kube-master kubectl get pods --all-namespaces \
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get pods --all-namespaces \
           -o go-template='{{range $x := .items}}{{range $x.spec.containers}}{{$x.spec.nodeName}}{{" "}}{{$x.metadata.namespace}}{{" "}}{{$x.metadata.name}}{{" "}}{{.name}}{{"\n"}}{{end}}{{end}}' |
     while read node ns pod container; do
       echo "@@@ pod-${node}-${ns}-${pod}--${container}.log @@@"
-      docker exec kube-master kubectl logs -n "${ns}" -c "${container}" "${pod}"
+      docker exec "${CLUSTER_PREFIX}kube-master" kubectl logs -n "${ns}" -c "${container}" "${pod}"
     done
   echo "@@@ kubectl-all.txt @@@"
-  docker exec kube-master kubectl get all --all-namespaces -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get all --all-namespaces -o wide
   echo "@@@ describe-all.txt @@@"
-  docker exec kube-master kubectl describe all --all-namespaces
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl describe all --all-namespaces
   echo "@@@ nodes.txt @@@"
-  docker exec kube-master kubectl get nodes -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get nodes -o wide
 }
 
 function dind::dump64 {
   echo "%%% start-base64 %%%"
-  dind::dump | docker exec -i kube-master /bin/sh -c "lzma | base64 -w 100"
+  dind::dump | docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "lzma | base64 -w 100"
   echo "%%% end-base64 %%%"
 }
 

--- a/fixed/dind-cluster-v1.7.sh
+++ b/fixed/dind-cluster-v1.7.sh
@@ -57,6 +57,12 @@ fi
 POD_NETWORK_CIDR="${POD_NETWORK_CIDR:-${DEFAULT_POD_NETWORK_CIDR}}"
 ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
 GCE_HOSTED="${GCE_HOSTED:-false}"
+
+if [[ "${CLUSTER_PREFIX:-}" ]]; then
+  CLUSTER_PREFIX="${CLUSTER_PREFIX:-}-" # auto-delimit the prefix /w a hyphen
+else
+  CLUSTER_PREFIX=""
+fi
 if [[ ${IP_MODE} = "ipv6" ]]; then
     DIND_SUBNET="${DIND_SUBNET:-fd00:10::}"
     dind_ip_base="${DIND_SUBNET}"
@@ -181,7 +187,7 @@ function dind::volume-exists {
 
 function dind::create-volume {
   local name="$1"
-  docker volume create --label mirantis.kubeadm_dind_cluster --name "${name}" >/dev/null
+  docker volume create --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster --name "${name}" >/dev/null
 }
 
 # We mount /boot and /lib/modules into the container
@@ -417,13 +423,13 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect kubeadm-dind-net >&/dev/null; then
+  if ! docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" kubeadm-dind-net >/dev/null
+    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" "${CLUSTER_PREFIX}kubeadm-dind-net" >/dev/null
   fi
 }
 
@@ -472,7 +478,7 @@ BIND9_EOF
 		docker-machine ssh k8s-dind sudo mkdir -p ${bind9_path}/conf ${bind9_path}/cache
 		docker-machine ssh k8s-dind sudo cp /home/docker-user/bind9-named.conf ${bind9_path}/conf/named.conf
 	    fi
-	    docker run -d --name bind9 --hostname bind9 --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+	    docker run -d --name bind9 --hostname bind9 --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip6 $dns_server --dns $dns_server \
 		   -v ${bind9_path}/conf/named.conf:/etc/bind/named.conf \
@@ -487,7 +493,7 @@ BIND9_EOF
 function dind::ensure-nat {
     if [[  ${IP_MODE} = "ipv6" ]]; then
         if ! docker ps | grep tayga >&/dev/null; then
-            docker run -d --name tayga --hostname tayga --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+            docker run -d --name tayga --hostname tayga --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip 172.18.0.200 --ip6 ${LOCAL_NAT64_SERVER} --dns ${REMOTE_DNS64_V4SERVER} --dns ${dns_server} \
 		   -e TAYGA_CONF_PREFIX=${DNS64_PREFIX_CIDR} -e TAYGA_CONF_IPV4_ADDR=172.18.0.200 \
@@ -573,10 +579,10 @@ function dind::run {
   docker run \
 	 -e IP_MODE="${IP_MODE}" \
          -d --privileged \
-         --net kubeadm-dind-net \
+         --net "${CLUSTER_PREFIX}kubeadm-dind-net" \
          --name "${container_name}" \
          --hostname "${container_name}" \
-         -l mirantis.kubeadm_dind_cluster \
+         -l mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
          -v ${volume_name}:/dind \
          ${opts[@]+"${opts[@]}"} \
          "${DIND_IMAGE}" \
@@ -621,9 +627,9 @@ function dind::configure-kubectl {
       host="[::1]"
     fi
   fi
-  "${kubectl}" config set-cluster dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
-  "${kubectl}" config set-context dind --cluster=dind
-  "${kubectl}" config use-context dind
+  "${kubectl}" config set-cluster ${CLUSTER_PREFIX}dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
+  "${kubectl}" config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind
+  "${kubectl}" config use-context ${CLUSTER_PREFIX}dind
 }
 
 force_make_binaries=
@@ -683,7 +689,7 @@ function dind::deploy-dashboard {
 function dind::at-least-kubeadm-1-8 {
   # kubeadm 1.6 and below doesn't support 'version -o short' and will
   # thus produce an empty string
-  local ver="$(docker exec kube-master kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
+  local ver="$(docker exec "${CLUSTER_PREFIX}kube-master" kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
   if [[ ! ${ver} || ${ver} = v1.7 ]]; then
     return 1
   fi
@@ -696,7 +702,7 @@ function dind::init {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  local container_id=$(dind::run kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
+  local container_id=$(dind::run "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -716,7 +722,7 @@ function dind::init {
       bind_address="::"
     fi
     dind::proxy kube-master
-    docker exec -i kube-master /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
+    docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
 apiVersion: kubeadm.k8s.io/v1alpha1
 unifiedControlPlaneImage: mirantis/hypokube:final
 kind: MasterConfiguration
@@ -726,7 +732,7 @@ api:
 networking:
   ${pod_net_cidr}serviceSubnet: "${SERVICE_CIDR}"
 tokenTTL: 0s
-nodeName: kube-master
+nodeName: ${CLUSTER_PREFIX}kube-master
 apiServerExtraArgs:
   insecure-bind-address: "${bind_address}"
   insecure-port: "8080"
@@ -746,9 +752,9 @@ function dind::create-node-container {
     shift
   fi
   # if there's just one node currently, it's master, thus we need to use
-  # kube-node-1 hostname, if there are two nodes, we should pick
-  # kube-node-2 and so on
-  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
+  # ${CLUSTER_PREFIX}kube-node-1 hostname, if there are two nodes, we should pick
+  # ${CLUSTER_PREFIX}kube-node-2 and so on
+  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
   local node_ip="${dind_ip_base}$((next_node_index + 2))"
   local -a opts
   if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
@@ -760,7 +766,7 @@ function dind::create-node-container {
       opts+=(-e HYPERKUBE_SOURCE=build://)
     fi
   fi
-  dind::run ${reuse_volume} kube-node-${next_node_index} ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
+  dind::run ${reuse_volume} "${CLUSTER_PREFIX}kube-node-${next_node_index}" ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
 }
 
 function dind::join {
@@ -778,7 +784,7 @@ function dind::accelerate-kube-dns {
   dind::step "Patching kube-dns deployment to make it start faster"
   # Could do this on the host, too, but we don't want to require jq here
   # TODO: do this in wrapkubeadm
-  docker exec kube-master /bin/bash -c \
+  docker exec "${CLUSTER_PREFIX}kube-master" /bin/bash -c \
          "kubectl get deployment kube-dns -n kube-system -o json | jq '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds = 3|.spec.template.spec.containers[0].readinessProbe.periodSeconds = 3' | kubectl apply --force -f -"
 }
 
@@ -902,7 +908,7 @@ function dind::up {
   else
     # FIXME: this may fail depending on k8s/kubeadm version
     # FIXME: check for taint & retry if it's there
-    "${kubectl}" taint nodes kube-master node-role.kubernetes.io/master- || true
+    "${kubectl}" taint nodes "${CLUSTER_PREFIX}kube-master" node-role.kubernetes.io/master- || true
   fi
   case "${CNI_PLUGIN}" in
     bridge)
@@ -944,9 +950,9 @@ function dind::snapshot_container {
 
 function dind::snapshot {
   dind::step "Taking snapshot of the cluster"
-  dind::snapshot_container kube-master
+  dind::snapshot_container "${CLUSTER_PREFIX}kube-master"
   for ((n=1; n <= NUM_NODES; n++)); do
-    dind::snapshot_container "kube-node-${n}"
+    dind::snapshot_container "${CLUSTER_PREFIX}kube-node-${n}"
   done
   dind::wait-for-ready
 }
@@ -969,7 +975,7 @@ function dind::restore {
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -994,26 +1000,26 @@ function dind::restore {
 }
 
 function dind::down {
-  docker ps -a -q --filter=label=mirantis.kubeadm_dind_cluster | while read container_id; do
+  docker ps -a -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | while read container_id; do
     dind::step "Removing container:" "${container_id}"
     docker rm -fv "${container_id}"
   done
 }
 
 function dind::remove-volumes {
-  # docker 1.13+: docker volume ls -q -f label=mirantis.kubeadm_dind_cluster
-  docker volume ls -q | (grep '^kubeadm-dind' || true) | while read volume_id; do
+  # docker 1.13+: docker volume ls -q -f label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster
+  docker volume ls -q | (grep "^kubeadm-dind-${CLUSTER_PREFIX}" || true) | while read volume_id; do
     dind::step "Removing volume:" "${volume_id}"
     docker volume rm "${volume_id}"
   done
 }
 
 function dind::check-for-snapshot {
-  if ! dind::volume-exists "kubeadm-dind-kube-master"; then
+  if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-master"; then
     return 1
   fi
   for ((n=1; n <= NUM_NODES; n++)); do
-    if ! dind::volume-exists "kubeadm-dind-kube-node-${n}"; then
+    if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-node-${n}"; then
       return 1
     fi
   done
@@ -1067,9 +1073,9 @@ function dind::do-run-e2e {
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
-         cluster/kubectl.sh config set-context dind --cluster=dind &&
-         cluster/kubectl.sh config use-context dind &&
+         bash -c "cluster/kubectl.sh config set-cluster ${CLUSTER_PREFIX}dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         cluster/kubectl.sh config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind &&
+         cluster/kubectl.sh config use-context ${CLUSTER_PREFIX}dind &&
          go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
 }
 
@@ -1077,8 +1083,8 @@ function dind::clean {
   dind::down
   # dind::remove-images
   dind::remove-volumes
-  if docker network inspect kubeadm-dind-net >&/dev/null; then
-    docker network rm kubeadm-dind-net
+  if docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
+    docker network rm "${CLUSTER_PREFIX}kubeadm-dind-net"
   fi
 }
 
@@ -1130,7 +1136,7 @@ function dind::step {
 function dind::dump {
   set +e
   echo "*** Dumping cluster state ***"
-  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.kubeadm_dind_cluster); do
+  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster); do
     for service in kubelet.service dindnet.service criproxy.service dockershim.service; do
       if docker exec "${node}" systemctl is-enabled "${service}" >&/dev/null; then
         echo "@@@ service-${node}-${service}.log @@@"
@@ -1147,23 +1153,23 @@ function dind::dump {
     echo "@@@ ip-r-${node}.txt @@@"
     docker exec "${node}" ip r
   done
-  docker exec kube-master kubectl get pods --all-namespaces \
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get pods --all-namespaces \
           -o go-template='{{range $x := .items}}{{range $x.spec.containers}}{{$x.spec.nodeName}}{{" "}}{{$x.metadata.namespace}}{{" "}}{{$x.metadata.name}}{{" "}}{{.name}}{{"\n"}}{{end}}{{end}}' |
     while read node ns pod container; do
       echo "@@@ pod-${node}-${ns}-${pod}--${container}.log @@@"
-      docker exec kube-master kubectl logs -n "${ns}" -c "${container}" "${pod}"
+      docker exec "${CLUSTER_PREFIX}kube-master" kubectl logs -n "${ns}" -c "${container}" "${pod}"
     done
   echo "@@@ kubectl-all.txt @@@"
-  docker exec kube-master kubectl get all --all-namespaces -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get all --all-namespaces -o wide
   echo "@@@ describe-all.txt @@@"
-  docker exec kube-master kubectl describe all --all-namespaces
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl describe all --all-namespaces
   echo "@@@ nodes.txt @@@"
-  docker exec kube-master kubectl get nodes -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get nodes -o wide
 }
 
 function dind::dump64 {
   echo "%%% start-base64 %%%"
-  dind::dump | docker exec -i kube-master /bin/sh -c "lzma | base64 -w 100"
+  dind::dump | docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "lzma | base64 -w 100"
   echo "%%% end-base64 %%%"
 }
 

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -57,6 +57,12 @@ fi
 POD_NETWORK_CIDR="${POD_NETWORK_CIDR:-${DEFAULT_POD_NETWORK_CIDR}}"
 ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
 GCE_HOSTED="${GCE_HOSTED:-false}"
+
+if [[ "${CLUSTER_PREFIX:-}" ]]; then
+  CLUSTER_PREFIX="${CLUSTER_PREFIX:-}-" # auto-delimit the prefix /w a hyphen
+else
+  CLUSTER_PREFIX=""
+fi
 if [[ ${IP_MODE} = "ipv6" ]]; then
     DIND_SUBNET="${DIND_SUBNET:-fd00:10::}"
     dind_ip_base="${DIND_SUBNET}"
@@ -181,7 +187,7 @@ function dind::volume-exists {
 
 function dind::create-volume {
   local name="$1"
-  docker volume create --label mirantis.kubeadm_dind_cluster --name "${name}" >/dev/null
+  docker volume create --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster --name "${name}" >/dev/null
 }
 
 # We mount /boot and /lib/modules into the container
@@ -417,13 +423,13 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect kubeadm-dind-net >&/dev/null; then
+  if ! docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" kubeadm-dind-net >/dev/null
+    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" "${CLUSTER_PREFIX}kubeadm-dind-net" >/dev/null
   fi
 }
 
@@ -472,7 +478,7 @@ BIND9_EOF
 		docker-machine ssh k8s-dind sudo mkdir -p ${bind9_path}/conf ${bind9_path}/cache
 		docker-machine ssh k8s-dind sudo cp /home/docker-user/bind9-named.conf ${bind9_path}/conf/named.conf
 	    fi
-	    docker run -d --name bind9 --hostname bind9 --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+	    docker run -d --name bind9 --hostname bind9 --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip6 $dns_server --dns $dns_server \
 		   -v ${bind9_path}/conf/named.conf:/etc/bind/named.conf \
@@ -487,7 +493,7 @@ BIND9_EOF
 function dind::ensure-nat {
     if [[  ${IP_MODE} = "ipv6" ]]; then
         if ! docker ps | grep tayga >&/dev/null; then
-            docker run -d --name tayga --hostname tayga --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+            docker run -d --name tayga --hostname tayga --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip 172.18.0.200 --ip6 ${LOCAL_NAT64_SERVER} --dns ${REMOTE_DNS64_V4SERVER} --dns ${dns_server} \
 		   -e TAYGA_CONF_PREFIX=${DNS64_PREFIX_CIDR} -e TAYGA_CONF_IPV4_ADDR=172.18.0.200 \
@@ -573,10 +579,10 @@ function dind::run {
   docker run \
 	 -e IP_MODE="${IP_MODE}" \
          -d --privileged \
-         --net kubeadm-dind-net \
+         --net "${CLUSTER_PREFIX}kubeadm-dind-net" \
          --name "${container_name}" \
          --hostname "${container_name}" \
-         -l mirantis.kubeadm_dind_cluster \
+         -l mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
          -v ${volume_name}:/dind \
          ${opts[@]+"${opts[@]}"} \
          "${DIND_IMAGE}" \
@@ -621,9 +627,9 @@ function dind::configure-kubectl {
       host="[::1]"
     fi
   fi
-  "${kubectl}" config set-cluster dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
-  "${kubectl}" config set-context dind --cluster=dind
-  "${kubectl}" config use-context dind
+  "${kubectl}" config set-cluster ${CLUSTER_PREFIX}dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
+  "${kubectl}" config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind
+  "${kubectl}" config use-context ${CLUSTER_PREFIX}dind
 }
 
 force_make_binaries=
@@ -683,7 +689,7 @@ function dind::deploy-dashboard {
 function dind::at-least-kubeadm-1-8 {
   # kubeadm 1.6 and below doesn't support 'version -o short' and will
   # thus produce an empty string
-  local ver="$(docker exec kube-master kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
+  local ver="$(docker exec "${CLUSTER_PREFIX}kube-master" kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
   if [[ ! ${ver} || ${ver} = v1.7 ]]; then
     return 1
   fi
@@ -696,7 +702,7 @@ function dind::init {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  local container_id=$(dind::run kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
+  local container_id=$(dind::run "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -716,7 +722,7 @@ function dind::init {
       bind_address="::"
     fi
     dind::proxy kube-master
-    docker exec -i kube-master /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
+    docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
 apiVersion: kubeadm.k8s.io/v1alpha1
 unifiedControlPlaneImage: mirantis/hypokube:final
 kind: MasterConfiguration
@@ -726,7 +732,7 @@ api:
 networking:
   ${pod_net_cidr}serviceSubnet: "${SERVICE_CIDR}"
 tokenTTL: 0s
-nodeName: kube-master
+nodeName: ${CLUSTER_PREFIX}kube-master
 apiServerExtraArgs:
   insecure-bind-address: "${bind_address}"
   insecure-port: "8080"
@@ -746,9 +752,9 @@ function dind::create-node-container {
     shift
   fi
   # if there's just one node currently, it's master, thus we need to use
-  # kube-node-1 hostname, if there are two nodes, we should pick
-  # kube-node-2 and so on
-  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
+  # ${CLUSTER_PREFIX}kube-node-1 hostname, if there are two nodes, we should pick
+  # ${CLUSTER_PREFIX}kube-node-2 and so on
+  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
   local node_ip="${dind_ip_base}$((next_node_index + 2))"
   local -a opts
   if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
@@ -760,7 +766,7 @@ function dind::create-node-container {
       opts+=(-e HYPERKUBE_SOURCE=build://)
     fi
   fi
-  dind::run ${reuse_volume} kube-node-${next_node_index} ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
+  dind::run ${reuse_volume} "${CLUSTER_PREFIX}kube-node-${next_node_index}" ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
 }
 
 function dind::join {
@@ -778,7 +784,7 @@ function dind::accelerate-kube-dns {
   dind::step "Patching kube-dns deployment to make it start faster"
   # Could do this on the host, too, but we don't want to require jq here
   # TODO: do this in wrapkubeadm
-  docker exec kube-master /bin/bash -c \
+  docker exec "${CLUSTER_PREFIX}kube-master" /bin/bash -c \
          "kubectl get deployment kube-dns -n kube-system -o json | jq '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds = 3|.spec.template.spec.containers[0].readinessProbe.periodSeconds = 3' | kubectl apply --force -f -"
 }
 
@@ -902,7 +908,7 @@ function dind::up {
   else
     # FIXME: this may fail depending on k8s/kubeadm version
     # FIXME: check for taint & retry if it's there
-    "${kubectl}" taint nodes kube-master node-role.kubernetes.io/master- || true
+    "${kubectl}" taint nodes "${CLUSTER_PREFIX}kube-master" node-role.kubernetes.io/master- || true
   fi
   case "${CNI_PLUGIN}" in
     bridge)
@@ -944,9 +950,9 @@ function dind::snapshot_container {
 
 function dind::snapshot {
   dind::step "Taking snapshot of the cluster"
-  dind::snapshot_container kube-master
+  dind::snapshot_container "${CLUSTER_PREFIX}kube-master"
   for ((n=1; n <= NUM_NODES; n++)); do
-    dind::snapshot_container "kube-node-${n}"
+    dind::snapshot_container "${CLUSTER_PREFIX}kube-node-${n}"
   done
   dind::wait-for-ready
 }
@@ -969,7 +975,7 @@ function dind::restore {
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -994,26 +1000,26 @@ function dind::restore {
 }
 
 function dind::down {
-  docker ps -a -q --filter=label=mirantis.kubeadm_dind_cluster | while read container_id; do
+  docker ps -a -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | while read container_id; do
     dind::step "Removing container:" "${container_id}"
     docker rm -fv "${container_id}"
   done
 }
 
 function dind::remove-volumes {
-  # docker 1.13+: docker volume ls -q -f label=mirantis.kubeadm_dind_cluster
-  docker volume ls -q | (grep '^kubeadm-dind' || true) | while read volume_id; do
+  # docker 1.13+: docker volume ls -q -f label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster
+  docker volume ls -q | (grep "^kubeadm-dind-${CLUSTER_PREFIX}" || true) | while read volume_id; do
     dind::step "Removing volume:" "${volume_id}"
     docker volume rm "${volume_id}"
   done
 }
 
 function dind::check-for-snapshot {
-  if ! dind::volume-exists "kubeadm-dind-kube-master"; then
+  if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-master"; then
     return 1
   fi
   for ((n=1; n <= NUM_NODES; n++)); do
-    if ! dind::volume-exists "kubeadm-dind-kube-node-${n}"; then
+    if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-node-${n}"; then
       return 1
     fi
   done
@@ -1067,9 +1073,9 @@ function dind::do-run-e2e {
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
-         cluster/kubectl.sh config set-context dind --cluster=dind &&
-         cluster/kubectl.sh config use-context dind &&
+         bash -c "cluster/kubectl.sh config set-cluster ${CLUSTER_PREFIX}dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         cluster/kubectl.sh config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind &&
+         cluster/kubectl.sh config use-context ${CLUSTER_PREFIX}dind &&
          go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
 }
 
@@ -1077,8 +1083,8 @@ function dind::clean {
   dind::down
   # dind::remove-images
   dind::remove-volumes
-  if docker network inspect kubeadm-dind-net >&/dev/null; then
-    docker network rm kubeadm-dind-net
+  if docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
+    docker network rm "${CLUSTER_PREFIX}kubeadm-dind-net"
   fi
 }
 
@@ -1130,7 +1136,7 @@ function dind::step {
 function dind::dump {
   set +e
   echo "*** Dumping cluster state ***"
-  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.kubeadm_dind_cluster); do
+  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster); do
     for service in kubelet.service dindnet.service criproxy.service dockershim.service; do
       if docker exec "${node}" systemctl is-enabled "${service}" >&/dev/null; then
         echo "@@@ service-${node}-${service}.log @@@"
@@ -1147,23 +1153,23 @@ function dind::dump {
     echo "@@@ ip-r-${node}.txt @@@"
     docker exec "${node}" ip r
   done
-  docker exec kube-master kubectl get pods --all-namespaces \
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get pods --all-namespaces \
           -o go-template='{{range $x := .items}}{{range $x.spec.containers}}{{$x.spec.nodeName}}{{" "}}{{$x.metadata.namespace}}{{" "}}{{$x.metadata.name}}{{" "}}{{.name}}{{"\n"}}{{end}}{{end}}' |
     while read node ns pod container; do
       echo "@@@ pod-${node}-${ns}-${pod}--${container}.log @@@"
-      docker exec kube-master kubectl logs -n "${ns}" -c "${container}" "${pod}"
+      docker exec "${CLUSTER_PREFIX}kube-master" kubectl logs -n "${ns}" -c "${container}" "${pod}"
     done
   echo "@@@ kubectl-all.txt @@@"
-  docker exec kube-master kubectl get all --all-namespaces -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get all --all-namespaces -o wide
   echo "@@@ describe-all.txt @@@"
-  docker exec kube-master kubectl describe all --all-namespaces
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl describe all --all-namespaces
   echo "@@@ nodes.txt @@@"
-  docker exec kube-master kubectl get nodes -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get nodes -o wide
 }
 
 function dind::dump64 {
   echo "%%% start-base64 %%%"
-  dind::dump | docker exec -i kube-master /bin/sh -c "lzma | base64 -w 100"
+  dind::dump | docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "lzma | base64 -w 100"
   echo "%%% end-base64 %%%"
 }
 

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -57,6 +57,12 @@ fi
 POD_NETWORK_CIDR="${POD_NETWORK_CIDR:-${DEFAULT_POD_NETWORK_CIDR}}"
 ETCD_HOST="${ETCD_HOST:-127.0.0.1}"
 GCE_HOSTED="${GCE_HOSTED:-false}"
+
+if [[ "${CLUSTER_PREFIX:-}" ]]; then
+  CLUSTER_PREFIX="${CLUSTER_PREFIX:-}-" # auto-delimit the prefix /w a hyphen
+else
+  CLUSTER_PREFIX=""
+fi
 if [[ ${IP_MODE} = "ipv6" ]]; then
     DIND_SUBNET="${DIND_SUBNET:-fd00:10::}"
     dind_ip_base="${DIND_SUBNET}"
@@ -181,7 +187,7 @@ function dind::volume-exists {
 
 function dind::create-volume {
   local name="$1"
-  docker volume create --label mirantis.kubeadm_dind_cluster --name "${name}" >/dev/null
+  docker volume create --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster --name "${name}" >/dev/null
 }
 
 # We mount /boot and /lib/modules into the container
@@ -417,13 +423,13 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect kubeadm-dind-net >&/dev/null; then
+  if ! docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" kubeadm-dind-net >/dev/null
+    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" "${CLUSTER_PREFIX}kubeadm-dind-net" >/dev/null
   fi
 }
 
@@ -472,7 +478,7 @@ BIND9_EOF
 		docker-machine ssh k8s-dind sudo mkdir -p ${bind9_path}/conf ${bind9_path}/cache
 		docker-machine ssh k8s-dind sudo cp /home/docker-user/bind9-named.conf ${bind9_path}/conf/named.conf
 	    fi
-	    docker run -d --name bind9 --hostname bind9 --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+	    docker run -d --name bind9 --hostname bind9 --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip6 $dns_server --dns $dns_server \
 		   -v ${bind9_path}/conf/named.conf:/etc/bind/named.conf \
@@ -487,7 +493,7 @@ BIND9_EOF
 function dind::ensure-nat {
     if [[  ${IP_MODE} = "ipv6" ]]; then
         if ! docker ps | grep tayga >&/dev/null; then
-            docker run -d --name tayga --hostname tayga --net kubeadm-dind-net --label mirantis.kubeadm_dind_cluster \
+            docker run -d --name tayga --hostname tayga --net "${CLUSTER_PREFIX}kubeadm-dind-net" --label mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
 		   --sysctl net.ipv6.conf.all.disable_ipv6=0 --sysctl net.ipv6.conf.all.forwarding=1 \
 		   --privileged=true --ip 172.18.0.200 --ip6 ${LOCAL_NAT64_SERVER} --dns ${REMOTE_DNS64_V4SERVER} --dns ${dns_server} \
 		   -e TAYGA_CONF_PREFIX=${DNS64_PREFIX_CIDR} -e TAYGA_CONF_IPV4_ADDR=172.18.0.200 \
@@ -573,10 +579,10 @@ function dind::run {
   docker run \
 	 -e IP_MODE="${IP_MODE}" \
          -d --privileged \
-         --net kubeadm-dind-net \
+         --net "${CLUSTER_PREFIX}kubeadm-dind-net" \
          --name "${container_name}" \
          --hostname "${container_name}" \
-         -l mirantis.kubeadm_dind_cluster \
+         -l mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster \
          -v ${volume_name}:/dind \
          ${opts[@]+"${opts[@]}"} \
          "${DIND_IMAGE}" \
@@ -621,9 +627,9 @@ function dind::configure-kubectl {
       host="[::1]"
     fi
   fi
-  "${kubectl}" config set-cluster dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
-  "${kubectl}" config set-context dind --cluster=dind
-  "${kubectl}" config use-context dind
+  "${kubectl}" config set-cluster ${CLUSTER_PREFIX}dind --server="http://${host}:${APISERVER_PORT}" --insecure-skip-tls-verify=true
+  "${kubectl}" config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind
+  "${kubectl}" config use-context ${CLUSTER_PREFIX}dind
 }
 
 force_make_binaries=
@@ -683,7 +689,7 @@ function dind::deploy-dashboard {
 function dind::at-least-kubeadm-1-8 {
   # kubeadm 1.6 and below doesn't support 'version -o short' and will
   # thus produce an empty string
-  local ver="$(docker exec kube-master kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
+  local ver="$(docker exec "${CLUSTER_PREFIX}kube-master" kubeadm version -o short 2>/dev/null|sed 's/^\(v[0-9]*\.[0-9]*\).*$/\1/')"
   if [[ ! ${ver} || ${ver} = v1.7 ]]; then
     return 1
   fi
@@ -696,7 +702,7 @@ function dind::init {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  local container_id=$(dind::run kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
+  local container_id=$(dind::run "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -716,7 +722,7 @@ function dind::init {
       bind_address="::"
     fi
     dind::proxy kube-master
-    docker exec -i kube-master /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
+    docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "cat >/etc/kubeadm.conf" <<EOF
 apiVersion: kubeadm.k8s.io/v1alpha1
 unifiedControlPlaneImage: mirantis/hypokube:final
 kind: MasterConfiguration
@@ -726,7 +732,7 @@ api:
 networking:
   ${pod_net_cidr}serviceSubnet: "${SERVICE_CIDR}"
 tokenTTL: 0s
-nodeName: kube-master
+nodeName: ${CLUSTER_PREFIX}kube-master
 apiServerExtraArgs:
   insecure-bind-address: "${bind_address}"
   insecure-port: "8080"
@@ -746,9 +752,9 @@ function dind::create-node-container {
     shift
   fi
   # if there's just one node currently, it's master, thus we need to use
-  # kube-node-1 hostname, if there are two nodes, we should pick
-  # kube-node-2 and so on
-  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
+  # ${CLUSTER_PREFIX}kube-node-1 hostname, if there are two nodes, we should pick
+  # ${CLUSTER_PREFIX}kube-node-2 and so on
+  local next_node_index=${1:-$(docker ps -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | wc -l | sed 's/^ *//g')}
   local node_ip="${dind_ip_base}$((next_node_index + 2))"
   local -a opts
   if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
@@ -760,7 +766,7 @@ function dind::create-node-container {
       opts+=(-e HYPERKUBE_SOURCE=build://)
     fi
   fi
-  dind::run ${reuse_volume} kube-node-${next_node_index} ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
+  dind::run ${reuse_volume} "${CLUSTER_PREFIX}kube-node-${next_node_index}" ${node_ip} $((next_node_index + 1)) "" ${opts[@]+"${opts[@]}"}
 }
 
 function dind::join {
@@ -778,7 +784,7 @@ function dind::accelerate-kube-dns {
   dind::step "Patching kube-dns deployment to make it start faster"
   # Could do this on the host, too, but we don't want to require jq here
   # TODO: do this in wrapkubeadm
-  docker exec kube-master /bin/bash -c \
+  docker exec "${CLUSTER_PREFIX}kube-master" /bin/bash -c \
          "kubectl get deployment kube-dns -n kube-system -o json | jq '.spec.template.spec.containers[0].readinessProbe.initialDelaySeconds = 3|.spec.template.spec.containers[0].readinessProbe.periodSeconds = 3' | kubectl apply --force -f -"
 }
 
@@ -902,7 +908,7 @@ function dind::up {
   else
     # FIXME: this may fail depending on k8s/kubeadm version
     # FIXME: check for taint & retry if it's there
-    "${kubectl}" taint nodes kube-master node-role.kubernetes.io/master- || true
+    "${kubectl}" taint nodes "${CLUSTER_PREFIX}kube-master" node-role.kubernetes.io/master- || true
   fi
   case "${CNI_PLUGIN}" in
     bridge)
@@ -944,9 +950,9 @@ function dind::snapshot_container {
 
 function dind::snapshot {
   dind::step "Taking snapshot of the cluster"
-  dind::snapshot_container kube-master
+  dind::snapshot_container "${CLUSTER_PREFIX}kube-master"
   for ((n=1; n <= NUM_NODES; n++)); do
-    dind::snapshot_container "kube-node-${n}"
+    dind::snapshot_container "${CLUSTER_PREFIX}kube-node-${n}"
   done
   dind::wait-for-ready
 }
@@ -969,7 +975,7 @@ function dind::restore {
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r kube-master "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "${CLUSTER_PREFIX}kube-master" "${kube_master_ip}" 1 ${local_host}:${APISERVER_PORT}:8080 ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -994,26 +1000,26 @@ function dind::restore {
 }
 
 function dind::down {
-  docker ps -a -q --filter=label=mirantis.kubeadm_dind_cluster | while read container_id; do
+  docker ps -a -q --filter=label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster | while read container_id; do
     dind::step "Removing container:" "${container_id}"
     docker rm -fv "${container_id}"
   done
 }
 
 function dind::remove-volumes {
-  # docker 1.13+: docker volume ls -q -f label=mirantis.kubeadm_dind_cluster
-  docker volume ls -q | (grep '^kubeadm-dind' || true) | while read volume_id; do
+  # docker 1.13+: docker volume ls -q -f label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster
+  docker volume ls -q | (grep "^kubeadm-dind-${CLUSTER_PREFIX}" || true) | while read volume_id; do
     dind::step "Removing volume:" "${volume_id}"
     docker volume rm "${volume_id}"
   done
 }
 
 function dind::check-for-snapshot {
-  if ! dind::volume-exists "kubeadm-dind-kube-master"; then
+  if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-master"; then
     return 1
   fi
   for ((n=1; n <= NUM_NODES; n++)); do
-    if ! dind::volume-exists "kubeadm-dind-kube-node-${n}"; then
+    if ! dind::volume-exists "kubeadm-dind-${CLUSTER_PREFIX}kube-node-${n}"; then
       return 1
     fi
   done
@@ -1067,9 +1073,9 @@ function dind::do-run-e2e {
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
-         cluster/kubectl.sh config set-context dind --cluster=dind &&
-         cluster/kubectl.sh config use-context dind &&
+         bash -c "cluster/kubectl.sh config set-cluster ${CLUSTER_PREFIX}dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         cluster/kubectl.sh config set-context ${CLUSTER_PREFIX}dind --cluster=${CLUSTER_PREFIX}dind &&
+         cluster/kubectl.sh config use-context ${CLUSTER_PREFIX}dind &&
          go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
 }
 
@@ -1077,8 +1083,8 @@ function dind::clean {
   dind::down
   # dind::remove-images
   dind::remove-volumes
-  if docker network inspect kubeadm-dind-net >&/dev/null; then
-    docker network rm kubeadm-dind-net
+  if docker network inspect "${CLUSTER_PREFIX}kubeadm-dind-net" >&/dev/null; then
+    docker network rm "${CLUSTER_PREFIX}kubeadm-dind-net"
   fi
 }
 
@@ -1130,7 +1136,7 @@ function dind::step {
 function dind::dump {
   set +e
   echo "*** Dumping cluster state ***"
-  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.kubeadm_dind_cluster); do
+  for node in $(docker ps --format '{{.Names}}' --filter label=mirantis.${CLUSTER_PREFIX}kubeadm_dind_cluster); do
     for service in kubelet.service dindnet.service criproxy.service dockershim.service; do
       if docker exec "${node}" systemctl is-enabled "${service}" >&/dev/null; then
         echo "@@@ service-${node}-${service}.log @@@"
@@ -1147,23 +1153,23 @@ function dind::dump {
     echo "@@@ ip-r-${node}.txt @@@"
     docker exec "${node}" ip r
   done
-  docker exec kube-master kubectl get pods --all-namespaces \
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get pods --all-namespaces \
           -o go-template='{{range $x := .items}}{{range $x.spec.containers}}{{$x.spec.nodeName}}{{" "}}{{$x.metadata.namespace}}{{" "}}{{$x.metadata.name}}{{" "}}{{.name}}{{"\n"}}{{end}}{{end}}' |
     while read node ns pod container; do
       echo "@@@ pod-${node}-${ns}-${pod}--${container}.log @@@"
-      docker exec kube-master kubectl logs -n "${ns}" -c "${container}" "${pod}"
+      docker exec "${CLUSTER_PREFIX}kube-master" kubectl logs -n "${ns}" -c "${container}" "${pod}"
     done
   echo "@@@ kubectl-all.txt @@@"
-  docker exec kube-master kubectl get all --all-namespaces -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get all --all-namespaces -o wide
   echo "@@@ describe-all.txt @@@"
-  docker exec kube-master kubectl describe all --all-namespaces
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl describe all --all-namespaces
   echo "@@@ nodes.txt @@@"
-  docker exec kube-master kubectl get nodes -o wide
+  docker exec "${CLUSTER_PREFIX}kube-master" kubectl get nodes -o wide
 }
 
 function dind::dump64 {
   echo "%%% start-base64 %%%"
-  dind::dump | docker exec -i kube-master /bin/sh -c "lzma | base64 -w 100"
+  dind::dump | docker exec -i "${CLUSTER_PREFIX}kube-master" /bin/sh -c "lzma | base64 -w 100"
   echo "%%% end-base64 %%%"
 }
 


### PR DESCRIPTION
This PR adds a config-var, `CLUSTER_PREFIX`, used for naming the containers, volumes, and network for your cluster.  
This allows you to create multiple clusters on the same docker daemon.  
When combined with `APISERVER_PORT` and `DIND_SUBNET`, you can run multiple clusters side-by-side.  

`CLUSTER_PREFIX` allows you to `up`, `down`, `clean`, and etc. for an individual cluster.  
I'm using this to test multiple changes in isolation and have found it useful.  
Please try it out, and let me know what you think.  

This loop:
```bash
for i in 1 2 3; do CLUSTER_PREFIX="test${i}" APISERVER_PORT="808${i}" DIND_SUBNET="10.19${i}.0.1" CNI_PLUGIN=weave fixed/dind-cluster-v1.8.sh up; done
```
Results in:
```bash
❯ kubectl config get-contexts
CURRENT   NAME                                                 CLUSTER                                              AUTHINFO                                             NAMESPACE
          test3-dind                                           test3-dind
          test4-dind                                           test4-dind
*         test5-dind                                           test5-dind
          docker-for-desktop                                   docker-for-desktop-cluster                           docker-for-desktop

❯ docker ps
CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS                      NAMES
7a5af0c1372b        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   10 minutes ago      Up 10 minutes       8080/tcp                   test3-kube-node-2
c7d22460c2bf        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   10 minutes ago      Up 10 minutes       127.0.0.1:8083->8080/tcp   test3-kube-master
e2df2a8d6362        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   10 minutes ago      Up 10 minutes       8080/tcp                   test3-kube-node-1
898a5598c40c        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   8 minutes ago       Up 8 minutes        8080/tcp                   test4-kube-node-2
34fb43c3c0fd        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   8 minutes ago       Up 8 minutes        8080/tcp                   test4-kube-node-1
debe845bace3        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   8 minutes ago       Up 8 minutes        127.0.0.1:8084->8080/tcp   test4-kube-master
f005bc7be12f        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   6 minutes ago       Up 6 minutes        8080/tcp                   test5-kube-node-2
ee5fb124ad43        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   6 minutes ago       Up 6 minutes        8080/tcp                   test5-kube-node-1
3a70eb8ee845        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   6 minutes ago       Up 6 minutes        127.0.0.1:8085->8080/tcp   test5-kube-master

❯ docker network ls | grep dind
e5f0cb9fa6dd        test3-kubeadm-dind-net   bridge              local
726fca1ab1c1        test4-kubeadm-dind-net   bridge              local
ed2cbfbb4130        test5-kubeadm-dind-net   bridge              local
```
The 3 dashboards should be available at
- http://localhost:8083/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#!/workload?namespace=kube-system
- http://localhost:8084/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#!/workload?namespace=kube-system
- http://localhost:8085/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#!/workload?namespace=kube-system

Bring down 1 cluster
```bash
CLUSTER_PREFIX=test5 fixed/dind-cluster-v1.8.sh down
```
Destroy 1 cluster
```bash
CLUSTER_PREFIX=test5 fixed/dind-cluster-v1.8.sh down
```
Destroy *all* clusters
```bash
fixed/dind-cluster-v1.8.sh down
```
 * This happens because all images have the top-level/no-prefix label baked in as part of the build  
   I didn't want to add a different label for this change  

Looking forward to some feedback 🙂