### PR TITLE
fix link to dashboard

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -862,7 +862,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/ui"
+  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {

--- a/fixed/dind-cluster-v1.7.sh
+++ b/fixed/dind-cluster-v1.7.sh
@@ -862,7 +862,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/ui"
+  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -862,7 +862,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/ui"
+  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -862,7 +862,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/ui"
+  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {


### PR DESCRIPTION
the /ui redirect assumes dashboard is running on https and gives the
following since the version of dashboard used here does not do https:

/ui redirects to /api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/
```
Error: 'tls: oversized record received with length 20527'
Trying to reach: 'https://10.192.2.1:9090/'
```

since the /ui redirect is scheduled to go away in 1.10 it makes sense to
just link to the actual dashboard itself at
"http://localhost:8080/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy".