### PR TITLE
Remove the --require-kubeconfig=true flag which is obsolete in 1.10

### DIFF
--- a/image/kubelet.service
+++ b/image/kubelet.service
@@ -3,7 +3,7 @@ Description=kubelet: The Kubernetes Node Agent
 Documentation=http://kubernetes.io/docs/
 
 [Service]
-Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf --require-kubeconfig=true"
+Environment="KUBELET_KUBECONFIG_ARGS=--kubeconfig=/etc/kubernetes/kubelet.conf"
 Environment="KUBELET_SYSTEM_PODS_ARGS=--pod-manifest-path=/etc/kubernetes/manifests --allow-privileged=true"
 Environment="KUBELET_NETWORK_ARGS=--network-plugin=cni --cni-conf-dir=/etc/cni/net.d --cni-bin-dir=/opt/cni/bin"
 Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.local"

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -366,7 +366,7 @@ function dind::set-kubelet-dind-args {
   dind::fix-cgroups
   dind::maybe-enable-swap
   dind::enable-feature-gates
-  ding::maybe-use-require-kubeconfig
+  dind::maybe-use-require-kubeconfig
   if [[ ${#kubelet_dind_args[@]} -gt 0 ]]; then
     sed -i "s@KUBELET_DIND_ARGS=@KUBELET_DIND_ARGS=${kubelet_dind_args[*]}@" /lib/systemd/system/kubelet.service
   fi

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -352,11 +352,21 @@ function dind::enable-feature-gates {
   fi
 }
 
+function dind:maybe-use-require-kubeconfig {
+    # require-kubeconfig flag is obsolete starting with 1.8 and removed from 1.10
+    # Add it only for 1.7
+    if ! /k8s/hyperkube kubelet --version | grep -q 'v1\.7\.'; then
+        return
+    fi
+    kubelet_dind_args+=("--require-kubeconfig=true")
+}
+
 function dind::set-kubelet-dind-args {
   dind::maybe-use-bootstrap-kubeconfig
   dind::fix-cgroups
   dind::maybe-enable-swap
   dind::enable-feature-gates
+  ding::maybe-use-require-kubeconfig
   if [[ ${#kubelet_dind_args[@]} -gt 0 ]]; then
     sed -i "s@KUBELET_DIND_ARGS=@KUBELET_DIND_ARGS=${kubelet_dind_args[*]}@" /lib/systemd/system/kubelet.service
   fi

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -352,7 +352,7 @@ function dind::enable-feature-gates {
   fi
 }
 
-function dind:maybe-use-require-kubeconfig {
+function dind::maybe-use-require-kubeconfig {
     # require-kubeconfig flag is obsolete starting with 1.8 and removed from 1.10
     # Add it only for 1.7
     if ! /k8s/hyperkube kubelet --version | grep -q 'v1\.7\.'; then


### PR DESCRIPTION
kubelet service does not start because of the `--require-kubeconfig` flag which is obsolete beginning  with version 1.10.

Fix #82 