### PR TITLE
Fixes of script for 1.9 dind cluster.

### DIFF
--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -159,7 +159,7 @@ function dind::retry {
 }
 
 busybox_image="busybox:1.26.2"
-e2e_base_image="golang:1.7.1"
+e2e_base_image="golang:1.9.2"
 sys_volume_args=()
 build_volume_args=()
 
@@ -1102,7 +1102,7 @@ function dind::do-run-e2e {
          bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${APISERVER_PORT}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
-         go run hack/e2e.go -- --v --test --check-version-skew=false --test_args='${test_args}'"
+         go run hack/e2e.go -- --v 6 --test --check-version-skew=false --test_args='${test_args}'"
 }
 
 function dind::clean {


### PR DESCRIPTION
* Bumped golang version from 1.7.1 to 1.9.2.
* Fixed --v parameter for kubetest.