### PR TITLE
google cloud sdk should be only used when needed

### DIFF
--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -116,10 +116,6 @@ function dind::get-binary-from-url {
 function dind::get-binary {
   local filename="$1"
   local src="$2"
-  if [ ! -d "google-cloud-sdk" ]
-  then
-    dind::install-google-cloud-sdk
-  fi
 
   if [[ ${src} = "build://" ]]; then
     dind::get-binary-from-build-data-container "${filename}"


### PR DESCRIPTION
After recent changes in wrapkubeadm, we're always downloading google cloud sdk.
It should be only downloaded when needed.

Fixes #98 