### PR TITLE
change mount points for /sys/kernel/debug to shared to support Weave

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -979,6 +979,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
+    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 

--- a/fixed/dind-cluster-v1.7.sh
+++ b/fixed/dind-cluster-v1.7.sh
@@ -979,6 +979,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
+    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 
@@ -1358,6 +1359,9 @@ case "${1:-}" in
     ;;
   clean)
     dind::clean
+    ;;
+  copy-image)
+    dind::copy-image
     ;;
   e2e)
     shift

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -979,6 +979,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
+    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 
@@ -1358,6 +1359,9 @@ case "${1:-}" in
     ;;
   clean)
     dind::clean
+    ;;
+  copy-image)
+    dind::copy-image
     ;;
   e2e)
     shift

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -979,6 +979,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
+    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 
@@ -1358,6 +1359,9 @@ case "${1:-}" in
     ;;
   clean)
     dind::clean
+    ;;
+  copy-image)
+    dind::copy-image
     ;;
   e2e)
     shift


### PR DESCRIPTION
Weave Scope AddOn throws an error and wont gather data as a result. The error in question is /sys/kernel/debug isn't mounted shared. A quick change to the fix-mounts function allows Weave Scope to run as expected.