### PR TITLE
Snapshot - improve detection of DNS service on d-in-d kube-master

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -886,7 +886,7 @@ function dind::wait-for-ready {
     sleep 1
   done
 
-  dind::step "Bringing up kube-dns and kubernetes-dashboard"
+  dind::step "Bringing up ${DNS_SERVICE} and kubernetes-dashboard"
   # on Travis 'scale' sometimes fails with 'error: Scaling the resource failed with: etcdserver: request timed out; Current resource version 442' here
   dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system ${DNS_SERVICE}
   dind::retry "${kubectl}" scale deployment --replicas=1 -n kube-system kubernetes-dashboard
@@ -894,7 +894,7 @@ function dind::wait-for-ready {
   ntries=200
   while ! dind::component-ready k8s-app=kube-dns || ! dind::component-ready app=kubernetes-dashboard; do
     if ((--ntries == 0)); then
-      echo "Error bringing up kube-dns and kubernetes-dashboard" >&2
+      echo "Error bringing up ${DNS_SERVICE} and kubernetes-dashboard" >&2
       exit 1
     fi
     echo -n "." >&2

--- a/image/snapshot
+++ b/image/snapshot
@@ -34,11 +34,7 @@ function snapshot::prepare {
     # FIXME: when using k8s 1.6 kube-dns pods stay in 'Terminating' state
     # Possibly related: https://github.com/kubernetes/kubernetes/issues/42685
 
-    if [[ -n `kubectl get deployment -n kube-system coredns` ]]; then
-      DNS_SERVICE=coredns
-    else
-      DNS_SERVICE=kube-dns
-    fi
+    DNS_SERVICE=`kubectl get deployment -n kube-system -l k8s-app=kube-dns -o name | cut -d / -f 2`
     snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${DNS_SERVICE}
     snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kubernetes-dashboard
     local n=60


### PR DESCRIPTION
Fix #109 

Also improve the labels for node to be scaled restored.


### log when CoreDNS:

```
root@francois-dind-coredns:~/go/src/github.com/kubernetes/kubernetes# ~/go/src/github.com/mirantis/kubeadm-dind-cluster/dind-cluster.sh snapshot
WARNING: No swap limit support
WARNING: No swap limit support
WARNING: No swap limit support
WARNING: No swap limit support
* Taking snapshot of the cluster 
deployment.extensions "coredns" scaled
deployment.extensions "kubernetes-dashboard" scaled
pod "kube-proxy-lcdbp" deleted
pod "kube-proxy-t9wm9" deleted
pod "kube-proxy-wz5r9" deleted
NAME                         READY     STATUS    RESTARTS   AGE
etcd-kube-master             1/1       Running   2          7m
kube-apiserver-kube-master   1/1       Running   2          9m
kube-scheduler-kube-master   1/1       Running   2          9m
tar: var/lib/kubelet/device-plugins/kubelet.sock: socket ignored
tar: var/lib/kubelet/device-plugins/kubelet.sock: socket ignored
tar: var/lib/kubelet/device-plugins/kubelet.sock: socket ignored
* Waiting for kube-proxy and the nodes 
.....[done]
* Bringing up coredns and kubernetes-dashboard 
deployment.extensions "coredns" scaled
deployment.extensions "kubernetes-dashboard" scaled
[done]

```


### log when kube-dns:

```
root@francois-dind-coredns:~/go/src/github.com/kubernetes/kubernetes# ~/go/src/github.com/mirantis/kubeadm-dind-cluster/dind-cluster.sh snapshot
WARNING: No swap limit support
WARNING: No swap limit support
WARNING: No swap limit support
WARNING: No swap limit support
* Taking snapshot of the cluster 
deployment.extensions "kube-dns" scaled
deployment.extensions "kubernetes-dashboard" scaled
pod "kube-proxy-8qvx6" deleted
pod "kube-proxy-grnwf" deleted
pod "kube-proxy-qdhgs" deleted
NAME                         READY     STATUS        RESTARTS   AGE
etcd-kube-master             1/1       Running       1          6m
kube-apiserver-kube-master   1/1       Running       1          6m
kube-dns-59c8ffd896-nv9rr    3/3       Terminating   0          3m
kube-proxy-8qvx6             0/1       Terminating   0          4m
kube-proxy-grnwf             0/1       Terminating   0          4m
kube-proxy-qdhgs             0/1       Terminating   0          4m
kube-scheduler-kube-master   1/1       Running       1          6m
tar: var/lib/kubelet/device-plugins/kubelet.sock: socket ignored
tar: var/lib/kubelet/device-plugins/kubelet.sock: socket ignored
tar: var/lib/kubelet/device-plugins/kubelet.sock: socket ignored
* Waiting for kube-proxy and the nodes 
.....[done]
* Bringing up kube-dns and kubernetes-dashboard 
deployment.extensions "kube-dns" scaled
deployment.extensions "kubernetes-dashboard" scaled
[done]
```
