### PR TITLE
[WIP] Support running multiple clusters

### DIFF
--- a/image/kubeadm.conf.tmpl
+++ b/image/kubeadm.conf.tmpl
@@ -12,7 +12,9 @@ networking:
   {{POD_SUBNET_DISABLE}}podSubnet: "{{POD_NETWORK_CIDR}}"
   serviceSubnet: "{{SVC_SUBNET}}"
 tokenTTL: 0s
-nodeName: kube-master
+nodeName: {{CLUSTER_PREFIX}}kube-master
 apiServerExtraArgs:
   insecure-bind-address: "{{BIND_ADDR}}"
   insecure-port: "8080"
+etcd:
+  image: k8s.gcr.io/etcd-amd64:3.2.17

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -62,7 +62,7 @@ function dind::proxy-cidr-and-no-conntrack {
 }
 
 is_master=
-if [[ "$(hostname)" = kube-master ]]; then
+if [[ "$(hostname)" =~ 'kube-master' ]]; then
   is_master=y
 fi
 


### PR DESCRIPTION
This is an updated version of #68. Thanks to @stealthybox for the initial hard work! Below is his original description:

This PR adds a config-var, `CLUSTER_PREFIX`, used for naming the containers, volumes, and network for your cluster.
This allows you to create multiple clusters on the same docker daemon.
When combined with `APISERVER_PORT` and `DIND_SUBNET`, you can run multiple clusters side-by-side.

`CLUSTER_PREFIX` allows you to up, down, clean, and etc. for an individual cluster.
I'm using this to test multiple changes in isolation and have found it useful.
Please try it out, and let me know what you think.

# Create 3 v1.8 clusters

This loop:

```
for i in 3 4 5; do CLUSTER_PREFIX="test${i}" APISERVER_PORT="808${i}" DIND_SUBNET="10.19${i}.0.1" CNI_PLUGIN=weave fixed/dind-cluster-v1.8.sh up; done
```

Results in:

```
❯ kubectl config get-contexts
CURRENT   NAME                                                 CLUSTER                                              AUTHINFO                                             NAMESPACE
          test3-dind                                           test3-dind
          test4-dind                                           test4-dind
*         test5-dind                                           test5-dind
          docker-for-desktop                                   docker-for-desktop-cluster                           docker-for-desktop

❯ docker ps
CONTAINER ID        IMAGE                                COMMAND                  CREATED             STATUS              PORTS                      NAMES
7a5af0c1372b        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   10 minutes ago      Up 10 minutes       8080/tcp                   test3-kube-node-2
c7d22460c2bf        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   10 minutes ago      Up 10 minutes       127.0.0.1:8083->8080/tcp   test3-kube-master
e2df2a8d6362        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   10 minutes ago      Up 10 minutes       8080/tcp                   test3-kube-node-1
898a5598c40c        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   8 minutes ago       Up 8 minutes        8080/tcp                   test4-kube-node-2
34fb43c3c0fd        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   8 minutes ago       Up 8 minutes        8080/tcp                   test4-kube-node-1
debe845bace3        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   8 minutes ago       Up 8 minutes        127.0.0.1:8084->8080/tcp   test4-kube-master
f005bc7be12f        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   6 minutes ago       Up 6 minutes        8080/tcp                   test5-kube-node-2
ee5fb124ad43        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   6 minutes ago       Up 6 minutes        8080/tcp                   test5-kube-node-1
3a70eb8ee845        mirantis/kubeadm-dind-cluster:v1.8   "/sbin/dind_init sys…"   6 minutes ago       Up 6 minutes        127.0.0.1:8085->8080/tcp   test5-kube-master

❯ docker network ls | grep kubeadm-dind
e5f0cb9fa6dd        test3-kubeadm-dind-net   bridge              local
726fca1ab1c1        test4-kubeadm-dind-net   bridge              local
ed2cbfbb4130        test5-kubeadm-dind-net   bridge              local

❯ docker volume ls | grep kubeadm-dind
local               kubeadm-dind-test3-kube-master
local               kubeadm-dind-test3-kube-node-1
local               kubeadm-dind-test3-kube-node-2
local               kubeadm-dind-test3-sys
local               kubeadm-dind-test4-kube-master
local               kubeadm-dind-test4-kube-node-1
local               kubeadm-dind-test4-kube-node-2
local               kubeadm-dind-test4-sys
local               kubeadm-dind-test5-kube-master
local               kubeadm-dind-test5-kube-node-1
local               kubeadm-dind-test5-kube-node-2
local               kubeadm-dind-test5-sys
```

The 3 dashboards should be available at

http://localhost:8083/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#!/workload?namespace=kube-system
http://localhost:8084/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#!/workload?namespace=kube-system
http://localhost:8085/api/v1/namespaces/kube-system/services/kubernetes-dashboard/proxy/#!/workload?namespace=kube-system

# Clean Up

```
# Stop 1 cluster
CLUSTER_PREFIX=test5 fixed/dind-cluster-v1.8.sh down
# Destroy 1 cluster
CLUSTER_PREFIX=test5 fixed/dind-cluster-v1.8.sh clean

# Stop all clusters
fixed/dind-cluster-v1.8.sh down-all
# Destroy all clusters
fixed/dind-cluster-v1.8.sh clean-all
```