### PR TITLE
Adding a default config.sh for stable branch

### DIFF
--- a/fixed/config-stable.sh
+++ b/fixed/config-stable.sh
@@ -1,0 +1,63 @@
+if [[ ${IP_MODE} = "ipv4" ]]; then
+    # DinD subnet (expected to be /16)
+    DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
+else
+    # DinD subnet (expected to be /64)
+    DIND_SUBNET="${DIND_SUBNET:-fd00:89::}"
+fi
+
+# Apiserver port
+APISERVER_PORT=${APISERVER_PORT:-8080}
+
+# Number of nodes. 0 nodes means just one master node.
+# In case of NUM_NODES=0 'node-role.kubernetes.io/master' taint is removed
+# from the master node.
+NUM_NODES=${NUM_NODES:-2}
+
+# Use non-dockerized build
+# KUBEADM_DIND_LOCAL=
+
+# Use prebuilt DIND image
+DIND_IMAGE="${DIND_IMAGE:-mirantis/kubeadm-dind-cluster:stable}"
+
+# Set to non-empty string to enable building kubeadm
+# BUILD_KUBEADM=y
+
+# Set to non-empty string to enable building hyperkube
+# BUILD_HYPERKUBE=y
+
+# download kubectl on the host
+# Set automatically based on DIND image version tag
+# if image version tag is of the form vNNN.NNN
+# LOCAL_KUBECTL_VERSION="${LOCAL_KUBECTL_VERSION:-v1.10}"
+
+# Set custom URL for Dashboard yaml file
+# DASHBOARD_URL="${DASHBOARD_URL:-https://rawgit.com/kubernetes/dashboard/bfab10151f012d1acc5dfb1979f3172e2400aa3c/src/deploy/kubernetes-dashboard.yaml}"
+
+# CNI plugin to use (bridge, flannel, calico, calico-kdd, weave). Defaults to 'bridge'
+# In case of 'bridge' plugin, additional hacks are employed to bridge
+# DIND containers together.
+CNI_PLUGIN="${CNI_PLUGIN:-bridge}"
+
+# When using Calico with Kubernetes as the datastore (calico-kdd) your
+# controller manager needs to be started with `--cluster-cidr=192.168.0.0/16`.
+# More information here: http://docs.projectcalico.org/v2.3/getting-started/kubernetes/installation/hosted/kubernetes-datastore/
+# POD_NETWORK_CIDR="192.168.0.0/16"
+
+# Set SKIP_SNAPSHOT to non-empty string to skip making the snapshot.
+# This may be useful for CI environment where the cluster is never
+# restarted after it's created.
+# SKIP_SNAPSHOT=y
+
+# Disable parallel running of e2e tests. Use this if you use a resource
+# constrained machine for e2e tests and get some flakes.
+# DIND_NO_PARALLEL_E2E=y
+
+# Any options to be passed to the docker run both on init and reup.
+# By default it's empty
+# MASTER_EXTRA_OPTS="  "
+
+# Define which DNS service to run
+# possible values are kube-dns (default) and coredns
+DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
+


### PR DESCRIPTION
Recently a stable branch was added for CI testing.
The scripts in the fixed directory were updated also, however that
only works for local clusters, they are bypassed when using GCE.
This change adds a default config file for that branch that can
be used by the CI test script when using GCE.
The config file can be copied over, then gce-setup.sh can be called
and the defaults for that branch will be used.
It is preferred to have the defaults in the kubeadm-dind-cluster repo
than in the CI repo.