### PR TITLE
Fix typos:resourse->resource, explicitely->explicitly

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -292,7 +292,7 @@ fi
 #
 # For legacy support, the user can specify DIND_LABEL, which will be used in the
 # resource names. If a cluster ID is specified (a hybrid case, where people are
-# using the new method, but want custom names), the resourse name will have the
+# using the new method, but want custom names), the resource name will have the
 # suffix "-#" with the cluster ID. If no cluster ID is specified (for backward
 # compatibility), then the resource name will be just the DIND_LABEL, and a pseudo-
 # random number from 1..13 will be generated for the cluster ID to be used in
@@ -1907,7 +1907,7 @@ function dind::down {
 }
 
 function dind::apiserver-port {
-  # APISERVER_PORT is explicitely set
+  # APISERVER_PORT is explicitly set
   if [ -n "${APISERVER_PORT:-}" ]
   then
     echo "$APISERVER_PORT"

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -292,7 +292,7 @@ fi
 #
 # For legacy support, the user can specify DIND_LABEL, which will be used in the
 # resource names. If a cluster ID is specified (a hybrid case, where people are
-# using the new method, but want custom names), the resourse name will have the
+# using the new method, but want custom names), the resource name will have the
 # suffix "-#" with the cluster ID. If no cluster ID is specified (for backward
 # compatibility), then the resource name will be just the DIND_LABEL, and a pseudo-
 # random number from 1..13 will be generated for the cluster ID to be used in
@@ -1907,7 +1907,7 @@ function dind::down {
 }
 
 function dind::apiserver-port {
-  # APISERVER_PORT is explicitely set
+  # APISERVER_PORT is explicitly set
   if [ -n "${APISERVER_PORT:-}" ]
   then
     echo "$APISERVER_PORT"

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -292,7 +292,7 @@ fi
 #
 # For legacy support, the user can specify DIND_LABEL, which will be used in the
 # resource names. If a cluster ID is specified (a hybrid case, where people are
-# using the new method, but want custom names), the resourse name will have the
+# using the new method, but want custom names), the resource name will have the
 # suffix "-#" with the cluster ID. If no cluster ID is specified (for backward
 # compatibility), then the resource name will be just the DIND_LABEL, and a pseudo-
 # random number from 1..13 will be generated for the cluster ID to be used in
@@ -1907,7 +1907,7 @@ function dind::down {
 }
 
 function dind::apiserver-port {
-  # APISERVER_PORT is explicitely set
+  # APISERVER_PORT is explicitly set
   if [ -n "${APISERVER_PORT:-}" ]
   then
     echo "$APISERVER_PORT"

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -292,7 +292,7 @@ fi
 #
 # For legacy support, the user can specify DIND_LABEL, which will be used in the
 # resource names. If a cluster ID is specified (a hybrid case, where people are
-# using the new method, but want custom names), the resourse name will have the
+# using the new method, but want custom names), the resource name will have the
 # suffix "-#" with the cluster ID. If no cluster ID is specified (for backward
 # compatibility), then the resource name will be just the DIND_LABEL, and a pseudo-
 # random number from 1..13 will be generated for the cluster ID to be used in
@@ -1907,7 +1907,7 @@ function dind::down {
 }
 
 function dind::apiserver-port {
-  # APISERVER_PORT is explicitely set
+  # APISERVER_PORT is explicitly set
   if [ -n "${APISERVER_PORT:-}" ]
   then
     echo "$APISERVER_PORT"

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -292,7 +292,7 @@ fi
 #
 # For legacy support, the user can specify DIND_LABEL, which will be used in the
 # resource names. If a cluster ID is specified (a hybrid case, where people are
-# using the new method, but want custom names), the resourse name will have the
+# using the new method, but want custom names), the resource name will have the
 # suffix "-#" with the cluster ID. If no cluster ID is specified (for backward
 # compatibility), then the resource name will be just the DIND_LABEL, and a pseudo-
 # random number from 1..13 will be generated for the cluster ID to be used in
@@ -1907,7 +1907,7 @@ function dind::down {
 }
 
 function dind::apiserver-port {
-  # APISERVER_PORT is explicitely set
+  # APISERVER_PORT is explicitly set
   if [ -n "${APISERVER_PORT:-}" ]
   then
     echo "$APISERVER_PORT"

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -292,7 +292,7 @@ fi
 #
 # For legacy support, the user can specify DIND_LABEL, which will be used in the
 # resource names. If a cluster ID is specified (a hybrid case, where people are
-# using the new method, but want custom names), the resourse name will have the
+# using the new method, but want custom names), the resource name will have the
 # suffix "-#" with the cluster ID. If no cluster ID is specified (for backward
 # compatibility), then the resource name will be just the DIND_LABEL, and a pseudo-
 # random number from 1..13 will be generated for the cluster ID to be used in
@@ -1907,7 +1907,7 @@ function dind::down {
 }
 
 function dind::apiserver-port {
-  # APISERVER_PORT is explicitely set
+  # APISERVER_PORT is explicitly set
   if [ -n "${APISERVER_PORT:-}" ]
   then
     echo "$APISERVER_PORT"

--- a/test/test-net-connectivity.sh
+++ b/test/test-net-connectivity.sh
@@ -37,7 +37,7 @@ function setup-test() {
   # instead of a potential locally available one.
   export PATH="${KUBECTL_DIR}:${PATH}"
 
-  # We set it here explicitely, even though dind-cluster.sh would default it, to
+  # We set it here explicitly, even though dind-cluster.sh would default it, to
   # later in the test be able to check if a resolved IP is prefixed with the
   # specified $DNS64_PREFIX
   export DNS64_PREFIX='fd00:10:64:ff9b::'


### PR DESCRIPTION
Fix typos:resourse->resource, explicitely->explicitly