### PR TITLE
Fix k8s master (1.14)

### DIFF
--- a/image/kubeadm.conf.1.13.tmpl
+++ b/image/kubeadm.conf.1.13.tmpl
@@ -43,7 +43,7 @@ etcd:
     dataDir: /var/lib/etcd
     image: ""
 featureGates: {{FEATURE_GATES}}
-imageRepository: k8s.gcr.io
+useHyperKubeImage: true
 kind: ClusterConfiguration
 kubernetesVersion: "{{KUBEADM_VERSION}}"
 networking:

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -164,6 +164,18 @@ function dind::ensure-binaries-and-hypokube {
     # After we "frob" the cluster, the hyperkube image is taken from /k8s directory.
     cp "${hyperkube_bin}" /hypokube/
     docker build -t "${hypokube_final_image}" -f /hypokube/hypokube.dkr /hypokube
+    hypokube_extra_tags=()
+    # In k8s 1.14+, we can't use unifiedControlPlaneImage anymore,
+    # so we have to resort to a hack by pretending we have already
+    # pulled the hyperkube image
+    # https://github.com/kubernetes/kubernetes/pull/70793
+    if kubeadm version -o short >&/dev/null; then
+        image_version="$(kubeadm version -o short|sed 's/-.*//')"
+        hypokube_extra_tags=("k8s.gcr.io/hyperkube:${image_version}")
+    fi
+    for tag in "${hypokube_extra_tags[@]}"; do
+        docker tag "${hypokube_final_image}" "${tag}"
+    done
   fi
 }
 


### PR DESCRIPTION
Always use CoreDNS and remove the feature gate from config.
Add workaround for `unifiedControlPlaneImage` removal kubernetes/kubernetes#70793
Fixes #250