### PR TITLE
Fix custom-docker-opts

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -134,6 +134,7 @@ RUN chmod +x /usr/local/bin/rundocker /usr/local/bin/dindnet /usr/local/bin/snap
     mkdir -p /etc/systemd/system/docker.service.wants && \
     ln -s /lib/systemd/system/dindnet.service /etc/systemd/system/docker.service.wants/ && \
     ln -s /dind/containerd /var/lib/containerd && \
+    mkdir -p /dind/containerd && \
     ln -s /k8s/hyperkube /usr/bin/kubectl && \
     ln -s /k8s/hyperkube /usr/bin/kubelet && \
     ln -s /k8s/kubeadm /usr/bin/kubeadm

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -66,9 +66,6 @@ if [[ -f /dind-sys/sys.tar ]]; then
   tar -C / -xf /dind-sys/sys.tar
 fi
 
-# make data dir for containerd (symlinked to /var/lib/containerd in the Dockerfile)
-mkdir -p /dind/containerd
-
 function dind::retry {
   # based on retry function in hack/jenkins/ scripts in k8s source
   for i in {1..10}; do


### PR DESCRIPTION
docker.service fails to start because /dind/containerd does not exist.
Move the creation of the directory from wrapkubeadm to the Dockerfile
Fixes #266